### PR TITLE
ENH: add visualization example

### DIFF
--- a/lcls-twincat-motion-example/_Config/NC/Axes/Example 3 Simulated Limits.xti
+++ b/lcls-twincat-motion-example/_Config/NC/Axes/Example 3 Simulated Limits.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.29" ClassName="CNcAxisDef" SubType="1">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.10" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-000000000035}" TcBaseType="true" HideType="true">UINTARR2</Name>
@@ -62,12 +62,10 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Encoder Status 4 (automatically linked):
+				<Comment><![CDATA[Encoder Status 4 (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -272,15 +270,13 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Drive Status 4 (automatically linked):
+				<Comment><![CDATA[Drive Status 4 (automatically linked):
 0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
 
 Drive Status 4 (manually linked):
 0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -622,7 +618,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1010,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1031,8 +1027,7 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1046,8 +1041,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1060,8 +1054,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1069,22 +1062,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1310,13 +1300,13 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -1327,10 +1317,6 @@ External Setpoint Generation:
 			<Dynamic AccelerationMaximum="100" DecelerationMaximum="100" Acceleration="100" Deceleration="100"/>
 			<Velo Maximum="10"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
-			<ParameterChanged>257</ParameterChanged>
-			<ParameterChanged>242</ParameterChanged>
-			<ParameterChanged>258</ParameterChanged>
-			<ParameterChanged>241</ParameterChanged>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="1">
 			<EncPara>
@@ -1348,15 +1334,6 @@ External Setpoint Generation:
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn2</Name>
-					</SubVar>
-					<SubVar>
-						<Name>nState4</Name>
-						<Comment>
-							<![CDATA[Encoder Status 4 (automatically linked):
-0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-						</Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn3</Name>
@@ -1419,18 +1396,6 @@ External Setpoint Generation:
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn2</Name>
 					</SubVar>
-					<SubVar>
-						<Name>nState4</Name>
-						<Comment>
-							<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-						</Comment>
-					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn3</Name>
 					</SubVar>
@@ -1459,23 +1424,19 @@ Drive Status 4 (manually linked):
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl2</Name>
-						<Comment>
-							<![CDATA[Digital Outputs Setpoint Generator:
+						<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl3</Name>
-						<Comment>
-							<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+						<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut3</Name>
@@ -1509,53 +1470,8 @@ Drive Status 4 (manually linked):
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 				<BitOffs>5376</BitOffs>
-				<SubVar>
-					<Name>AxisState</Name>
-					<Comment>
-						<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>HomingState</Name>
-					<Comment>
-						<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>CoupleState</Name>
-					<Comment>
-						<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-					</Comment>
-				</SubVar>
 			</Var>
 		</Vars>
 	</Axis>

--- a/lcls-twincat-motion-example/_Config/PLC/tc_mot_example.xti
+++ b/lcls-twincat-motion-example/_Config/PLC/tc_mot_example.xti
@@ -1,8 +1,26 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNestedPlcProjDef">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.10" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+			<BitSize>48</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>6</Elements>
+			</ArrayInfo>
+			<Format>
+				<Printf>%d.%d.%d.%d.%d.%d</Printf>
+				<Parameter>[0]</Parameter>
+				<Parameter>[1]</Parameter>
+				<Parameter>[2]</Parameter>
+				<Parameter>[3]</Parameter>
+				<Parameter>[4]</Parameter>
+				<Parameter>[5]</Parameter>
+			</Format>
+		</DataType>
+		<DataType>
+			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -113,6 +131,12 @@
 				<BitOffs>17</BitOffs>
 			</SubItem>
 			<SubItem>
+				<Name>IsDriveLimitActive</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>18</BitOffs>
+			</SubItem>
+			<SubItem>
 				<Name>ContinuousMotion</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
 				<BitSize>1</BitSize>
@@ -199,6 +223,11 @@
 			<Format Name="IEC">
 				<Printf>16#%08X</Printf>
 			</Format>
+			<Relations>
+				<Relation Priority="100">
+					<Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+				</Relation>
+			</Relations>
 		</DataType>
 		<DataType>
 			<Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
@@ -394,11 +423,11 @@
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -411,8 +440,7 @@
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -426,8 +454,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -440,8 +467,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -449,22 +475,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -653,6 +676,18 @@ External Setpoint Generation:
 				<BitOffs>1600</BitOffs>
 			</SubItem>
 			<SubItem>
+				<Name>AbsPhasingPos</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1664</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>TorqueOffset</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1728</BitOffs>
+			</SubItem>
+			<SubItem>
 				<Name>ActPosWithoutPosCorrection</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
 				<BitSize>64</BitSize>
@@ -690,13 +725,16 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
+				</Relation>
+				<Relation Priority="100">
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -880,388 +918,144 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{CA7AC114-7F2F-41DD-9644-D0667BBB7DBD}" Name="tc_mot_example" PrjFilePath="..\..\tc_mot_example\tc_mot_example.plcproj" TmcFilePath="..\..\tc_mot_example\tc_mot_example.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tc_motion_example\tc_motion_example.tmc">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tc_mot_example\tc_mot_example.tmc">
 			<Name>tc_mot_example Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
 				<Name>PlcTask Inputs</Name>
 				<Var>
+					<Name>lcls_twincat_motion.LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
+					<Comment><![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]></Comment>
+					<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+				</Var>
+				<Var>
 					<Name>Main.M1.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bHome</Name>
-					<Comment>
-						<![CDATA[NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>Main.M1.nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1.nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1.nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>Main.fbMotion1.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bHome</Name>
-					<Comment>
-						<![CDATA[NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>Main.M2.nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M2.nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M2.nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>Main.fbMotion2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bHome</Name>
-					<Comment>
-						<![CDATA[NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>Main.M3.nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M3.nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M3.nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>Main.fbMotion3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="2">
@@ -1272,9 +1066,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1287,9 +1079,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1302,9 +1092,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M3.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1312,6 +1100,32 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>
+			<Vars VarGrpType="8">
+				<Name>PlcTask Retains</Name>
+				<Var>
+					<Name>PMPS_GVL.SuccessfulPreemption</Name>
+					<Comment><![CDATA[ Any time BPTM applies a new BP request which is confirmed]]></Comment>
+					<Type>UDINT</Type>
+					<InOut>7</InOut>
+				</Var>
+				<Var>
+					<Name>PMPS_GVL.AccumulatedFF</Name>
+					<Comment><![CDATA[ Any time a FF occurs]]></Comment>
+					<Type>UDINT</Type>
+					<InOut>7</InOut>
+				</Var>
+			</Vars>
+			<Contexts>
+				<Context>
+					<Id NeedCalleeCall="true">0</Id>
+					<Name>PlcTask</Name>
+					<ManualConfig>
+						<OTCID>#x02010030</OTCID>
+					</ManualConfig>
+					<Priority>20</Priority>
+					<CycleTime>10000000</CycleTime>
+				</Context>
+			</Contexts>
 			<TaskPouOids>
 				<TaskPouOid Prio="20" OTCID="#x08502001"/>
 			</TaskPouOids>

--- a/lcls-twincat-motion-example/lcls-twincat-motion-example.tsproj
+++ b/lcls-twincat-motion-example/lcls-twincat-motion-example.tsproj
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
-	<Project ProjectGUID="{F8B30057-EC89-40A8-9A36-8FCF329C20AB}" TargetNetId="172.21.148.148.1.1" ShowHideConfigurations="#x306">
+<?xml version="1.0"?>
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.10">
+	<Project ProjectGUID="{F8B30057-EC89-40A8-9A36-8FCF329C20AB}" Target64Bit="true" ShowHideConfigurations="#x306">
 		<System>
+			<Settings MaxCpus="4" NonWinCpus="1">
+				<Cpu CpuId="3"/>
+			</Settings>
 			<Tasks>
 				<Task Id="3" Priority="20" CycleTime="100000" AmsPort="350" AdtTasks="true">
 					<Name>PlcTask</Name>

--- a/lcls-twincat-motion-example/tc_mot_example/GlobalTextList.TcGTLO
+++ b/lcls-twincat-motion-example/tc_mot_example/GlobalTextList.TcGTLO
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
+  <GlobalTextList Name="GlobalTextList" Id="{4093cc91-6394-46a8-add0-97d1284f821a}">
+    <XmlArchive>
+      <Data>
+        <o xml:space="preserve" t="GlobalTextListObject">
+          <l n="TextList" t="ArrayList" cet="TextListRow">
+            <o>
+              <v n="TextID">"102"</v>
+              <v n="TextDefault">"%f"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"467"</v>
+              <v n="TextDefault">"%X"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"459"</v>
+              <v n="TextDefault">"+"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"108"</v>
+              <v n="TextDefault">"-"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"463"</v>
+              <v n="TextDefault">"0 = Default Acceleration"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"465"</v>
+              <v n="TextDefault">"0 = Default Deceleration"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"462"</v>
+              <v n="TextDefault">"Acceleration: %f"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"165"</v>
+              <v n="TextDefault">"Axis 1"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"166"</v>
+              <v n="TextDefault">"Axis 2"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"167"</v>
+              <v n="TextDefault">"Axis 3"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"168"</v>
+              <v n="TextDefault">"Axis 4"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"112"</v>
+              <v n="TextDefault">"Clear"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"106"</v>
+              <v n="TextDefault">"Control"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"103"</v>
+              <v n="TextDefault">"Current Position"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"464"</v>
+              <v n="TextDefault">"Deceleration: %f"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"468"</v>
+              <v n="TextDefault">"Error Code"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"466"</v>
+              <v n="TextDefault">"Error:"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"110"</v>
+              <v n="TextDefault">"GO"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"111"</v>
+              <v n="TextDefault">"GO to set position"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"104"</v>
+              <v n="TextDefault">"High Limit Hit Indicator"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"101"</v>
+              <v n="TextDefault">"Low Limit Hit Indicator"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"456"</v>
+              <v n="TextDefault">"M1"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"114"</v>
+              <v n="TextDefault">"M2"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"184"</v>
+              <v n="TextDefault">"M3"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"105"</v>
+              <v n="TextDefault">"Moving:"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"107"</v>
+              <v n="TextDefault">"Set Position"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"460"</v>
+              <v n="TextDefault">"Settings"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"100"</v>
+              <v n="TextDefault">"Status"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"109"</v>
+              <v n="TextDefault">"Step Size"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"113"</v>
+              <v n="TextDefault">"STOP"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"461"</v>
+              <v n="TextDefault">"Velocity: %f"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+          </l>
+          <l n="Languages" t="ArrayList" />
+          <v n="GuidInit">{97632ad5-4477-48ec-93b7-2dd5df870f00}</v>
+          <v n="GuidReInit">{faa7a7b5-f61c-4ced-b725-3c390cf67bc7}</v>
+          <v n="GuidExitX">{8d36b0dc-7eac-411d-916f-fcacbaaadfb7}</v>
+        </o>
+      </Data>
+      <TypeList>
+        <Type n="ArrayList">System.Collections.ArrayList</Type>
+        <Type n="GlobalTextListObject">{63784cbb-9ba0-45e6-9d69-babf3f040511}</Type>
+        <Type n="Guid">System.Guid</Type>
+        <Type n="String">System.String</Type>
+        <Type n="TextListRow">{53da1be7-ad25-47c3-b0e8-e26286dad2e0}</Type>
+      </TypeList>
+    </XmlArchive>
+  </GlobalTextList>
+</TcPlcObject>

--- a/lcls-twincat-motion-example/tc_mot_example/POUs/Main.TcPOU
+++ b/lcls-twincat-motion-example/tc_mot_example/POUs/Main.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
   <POU Name="Main" Id="{7b41e58a-08f0-4959-90b4-af08ef5cbf10}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM Main
 VAR
@@ -26,6 +26,11 @@ VAR
     '}
     M3: DUT_MotionStage;
     fbMotion3: FB_MotionStage;
+
+    stM1Extra : DUT_MotionStage_Extras;
+    stM2Extra : DUT_MotionStage_Extras;
+    stM3Extra : DUT_MotionStage_Extras;
+
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[fbMotion1(stMotionStage := M1);
@@ -34,7 +39,17 @@ fbMotion3(stMotionStage := M3);
 M3.bHardwareEnable := TRUE;
 M3.bPowerSelf := TRUE;
 M3.bLimitForwardEnable := M3.Axis.NcToPlc.ActPos < 99.7;
-M3.bLimitBackwardEnable := M3.Axis.NcToPlc.ActPos > 0.2;]]></ST>
+M3.bLimitBackwardEnable := M3.Axis.NcToPlc.ActPos > 0.2;
+
+(* Update extras for visualization purposes *)
+stM1Extra.bVisuHighLim := NOT M1.bAllForwardEnable;
+stM1Extra.bVisuLowLim := NOT M1.bAllBackwardEnable;
+
+stM2Extra.bVisuHighLim := NOT M2.bAllForwardEnable;
+stM2Extra.bVisuLowLim := NOT M2.bAllBackwardEnable;
+
+stM3Extra.bVisuHighLim := NOT M3.bAllForwardEnable;
+stM3Extra.bVisuLowLim := NOT M3.bAllBackwardEnable;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion-example/tc_mot_example/VISUs/Visualization.TcVIS
+++ b/lcls-twincat-motion-example/tc_mot_example/VISUs/Visualization.TcVIS
@@ -1,0 +1,2237 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
+  <Visu Name="Visualization" Id="{46038cbc-714f-4f35-b697-7f366f8e7109}">
+    <XmlArchive>
+      <Data>
+        <o xml:space="preserve" t="VisualObject">
+          <n n="LastVisuLanguageModelEntry" />
+          <v n="UniqueIdGenerator">"3"</v>
+          <o n="VisualElemList" t="VisualElemList">
+            <l n="VisualElementList" t="VisualElemCollection" cet="GenericVisualElem">
+              <o>
+                <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                <l n="Elements" t="ArrayList" />
+                <n n="VisualElementDescription" />
+                <o n="VisualElemMemberList" t="VisualElemMemberList">
+                  <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                    <o>
+                      <v n="Id">571893170L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2341735680L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                        <o>
+                          <v n="Color">-2830136</v>
+                          <v n="CanonicalName">"Element-Frame-Color"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">438423234L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                        <o>
+                          <v n="Color">-65536</v>
+                          <v n="CanonicalName">"Element-Alarm-Frame-Color"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">2678395525L</v>
+                      <v n="Value" t="Int16">1</v>
+                    </o>
+                    <o>
+                      <v n="Id">2340015797L</v>
+                      <v n="Value">"HCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2565699834L</v>
+                      <v n="Value">"VCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4134387352L</v>
+                      <v n="Value">"NONE"</v>
+                    </o>
+                    <o>
+                      <v n="Id">1603690730L</v>
+                      <v n="Value">"Arial"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4253639993L</v>
+                      <v n="Value" t="Int16">12</v>
+                    </o>
+                    <o>
+                      <v n="Id">2729990903L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1213979116L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3488306084L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1999528970L</v>
+                      <v n="Value">"&lt;toggle/tap variable&gt;"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2812299069L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">494569607L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3719097617L</v>
+                      <v n="Value">0</v>
+                    </o>
+                    <o>
+                      <v n="Id">1649127785L</v>
+                      <v n="Value">4</v>
+                    </o>
+                    <o>
+                      <v n="Id">357335551L</v>
+                      <v n="Value">57</v>
+                    </o>
+                    <o>
+                      <v n="Id">2422045748L</v>
+                      <v n="Value">520</v>
+                    </o>
+                    <o>
+                      <v n="Id">2134141914L</v>
+                      <v n="Value">300</v>
+                    </o>
+                    <o>
+                      <v n="Id">394923068L</v>
+                      <v n="Value">false</v>
+                    </o>
+                    <o>
+                      <v n="Id">2322377816L</v>
+                      <v n="Value">"NO_FRAME"</v>
+                    </o>
+                    <o>
+                      <v n="Id">3549563837L</v>
+                      <v n="Value">"ANISOTROPIC"</v>
+                    </o>
+                    <o>
+                      <v n="Id">363316305L</v>
+                      <o n="Value" t="StructuredTypeNode">
+                        <v n="StructuredTypeNodeIsAnimation">false</v>
+                        <l n="TypeNodeChildren" t="ArrayList">
+                          <o t="DynamicArrayNode">
+                            <o n="DynamicArrayNodeCounterNode" t="BasicTypeNode">
+                              <v n="Flags">0L</v>
+                              <v n="BasicTypeNodeValue" t="Int16">1</v>
+                              <v n="BasicTypeNodeAcceptsExpression">false</v>
+                              <n n="BasicTypeNodeFastAccess" />
+                              <a n="BasicTypeNodeEnumValues" et="String" />
+                              <n n="EnumValueDisplayTextIds" />
+                              <n n="EnumValueVisibilityAttributeValues" />
+                              <n n="EnumValueLibraryId" />
+                              <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                              <l n="TypeNodeChildren" t="ArrayList" />
+                              <o n="TypeNodeType" t="TypeNodeType">
+                                <v n="TypeClass" t="TypeClass">Int</v>
+                                <v n="QualifiedName">"INT"</v>
+                                <v n="Name">"INT"</v>
+                              </o>
+                              <v n="TypeNodeName">"iCount"</v>
+                              <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                <v n="AttrFlags">1UL</v>
+                                <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                  <v>Visible</v>
+                                  <v>False</v>
+                                </d>
+                                <v n="ConvDone">true</v>
+                              </o>
+                              <v n="TypeNodeId" t="Int16">99</v>
+                              <v n="TypeNodeIdLong">87295452L</v>
+                              <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                              <n n="DisplayTextId" />
+                              <n n="DescriptionTextID" />
+                              <v n="DescriptionUseParent">false</v>
+                            </o>
+                            <n n="DynamicArrayNodeFastAccess" />
+                            <o n="ChildTemplate" t="VisualizationNode">
+                              <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                              <n n="VisuNodeReference" />
+                              <n n="VisNodeRefs33" />
+                              <l n="TypeNodeChildren" t="ArrayList" />
+                              <o n="TypeNodeType" t="TypeNodeType">
+                                <v n="TypeClass" t="TypeClass">Userdef</v>
+                                <v n="QualifiedName">"IVisualisation"</v>
+                                <v n="Name">"IVisualisation"</v>
+                              </o>
+                              <v n="TypeNodeName">""</v>
+                              <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                <v n="AttrFlags">0UL</v>
+                                <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                  <v>ieccodeconversion_useexistinginterface</v>
+                                  <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                                  <v>conditionalshow</v>
+                                  <v>visu_elemdev</v>
+                                  <v>''NORMAL__COMMENT</v>
+                                  <v> interface contains additional methods to IVisualElement</v>
+                                </d>
+                                <v n="ConvDone">true</v>
+                              </o>
+                              <v n="TypeNodeId" t="Int16">1</v>
+                              <v n="TypeNodeIdLong">3861935604L</v>
+                              <n n="LibraryId" />
+                              <n n="DisplayTextId" />
+                              <n n="DescriptionTextID" />
+                              <v n="DescriptionUseParent">false</v>
+                            </o>
+                            <l n="TypeNodeChildren" t="ArrayList" cet="VisualizationNode">
+                              <o>
+                                <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                                <n n="VisuNodeReference" />
+                                <v n="VisNodeRefs33">"lcls_twincat_motion.VISU_MotionStage"</v>
+                                <l n="TypeNodeChildren" t="ArrayList" cet="BasicTypeNode">
+                                  <o>
+                                    <v n="Flags">2L</v>
+                                    <n n="BasicTypeNodeValue" />
+                                    <v n="BasicTypeNodeAcceptsExpression">true</v>
+                                    <n n="BasicTypeNodeFastAccess" />
+                                    <a n="BasicTypeNodeEnumValues" et="String" />
+                                    <n n="EnumValueDisplayTextIds" />
+                                    <n n="EnumValueVisibilityAttributeValues" />
+                                    <n n="EnumValueLibraryId" />
+                                    <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                                    <l n="TypeNodeChildren" t="ArrayList" />
+                                    <o n="TypeNodeType" t="TypeNodeType">
+                                      <v n="TypeClass" t="TypeClass">Reference</v>
+                                      <v n="QualifiedName">"DUT_MotionStage"</v>
+                                      <v n="Name">"DUT_MotionStage"</v>
+                                    </o>
+                                    <v n="TypeNodeName">"VisuMotionStage"</v>
+                                    <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                      <v n="AttrFlags">0UL</v>
+                                      <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                                      <v n="ConvDone">true</v>
+                                    </o>
+                                    <v n="TypeNodeId" t="Int16">255</v>
+                                    <v n="TypeNodeIdLong">4223995186L</v>
+                                    <n n="LibraryId" />
+                                    <n n="DisplayTextId" />
+                                    <n n="DescriptionTextID" />
+                                    <v n="DescriptionUseParent">false</v>
+                                  </o>
+                                  <o>
+                                    <v n="Flags">2L</v>
+                                    <n n="BasicTypeNodeValue" />
+                                    <v n="BasicTypeNodeAcceptsExpression">true</v>
+                                    <n n="BasicTypeNodeFastAccess" />
+                                    <a n="BasicTypeNodeEnumValues" et="String" />
+                                    <n n="EnumValueDisplayTextIds" />
+                                    <n n="EnumValueVisibilityAttributeValues" />
+                                    <n n="EnumValueLibraryId" />
+                                    <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                                    <l n="TypeNodeChildren" t="ArrayList" />
+                                    <o n="TypeNodeType" t="TypeNodeType">
+                                      <v n="TypeClass" t="TypeClass">Reference</v>
+                                      <v n="QualifiedName">"DUT_MotionStage_Extras"</v>
+                                      <v n="Name">"DUT_MotionStage_Extras"</v>
+                                    </o>
+                                    <v n="TypeNodeName">"Extras"</v>
+                                    <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                      <v n="AttrFlags">0UL</v>
+                                      <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                                      <v n="ConvDone">true</v>
+                                    </o>
+                                    <v n="TypeNodeId" t="Int16">256</v>
+                                    <v n="TypeNodeIdLong">188078752L</v>
+                                    <n n="LibraryId" />
+                                    <n n="DisplayTextId" />
+                                    <n n="DescriptionTextID" />
+                                    <v n="DescriptionUseParent">false</v>
+                                  </o>
+                                </l>
+                                <o n="TypeNodeType" t="TypeNodeType">
+                                  <v n="TypeClass" t="TypeClass">Userdef</v>
+                                  <v n="QualifiedName">"IVisualisation"</v>
+                                  <v n="Name">"IVisualisation"</v>
+                                </o>
+                                <v n="TypeNodeName">"[0]"</v>
+                                <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                  <v n="AttrFlags">0UL</v>
+                                  <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                    <v>ieccodeconversion_useexistinginterface</v>
+                                    <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                                    <v>conditionalshow</v>
+                                    <v>visu_elemdev</v>
+                                    <v>''NORMAL__COMMENT</v>
+                                    <v> interface contains additional methods to IVisualElement</v>
+                                  </d>
+                                  <v n="ConvDone">true</v>
+                                </o>
+                                <v n="TypeNodeId" t="Int16">1</v>
+                                <v n="TypeNodeIdLong">2473092364L</v>
+                                <n n="LibraryId" />
+                                <n n="DisplayTextId" />
+                                <n n="DescriptionTextID" />
+                                <v n="DescriptionUseParent">false</v>
+                              </o>
+                            </l>
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Userdef</v>
+                              <v n="QualifiedName">"IVisualisation"</v>
+                              <v n="Name">"IVisualisation"</v>
+                            </o>
+                            <v n="TypeNodeName">"pReferences"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">1048577UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                <v>Visible</v>
+                                <v>False</v>
+                                <v>DefaultArraySize</v>
+                                <v>5</v>
+                                <v>VisibleChildren</v>
+                                <v>True</v>
+                                <v>ieccodeconversion_array</v>
+                                <v></v>
+                                <v>''NORMAL__COMMENT</v>
+                                <v> We hide this node to prevent having two References nodes
+ Nevertheless we want to make sure that the children are displayed</v>
+                              </d>
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">98</v>
+                            <v n="TypeNodeIdLong">1547928903L</v>
+                            <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                          <o t="BasicTypeNode">
+                            <v n="Flags">0L</v>
+                            <v n="BasicTypeNodeValue" t="Int16">1</v>
+                            <v n="BasicTypeNodeAcceptsExpression">false</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Int</v>
+                              <v n="QualifiedName">"INT"</v>
+                              <v n="Name">"INT"</v>
+                            </o>
+                            <v n="TypeNodeName">"iCount"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">1UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                <v>Visible</v>
+                                <v>False</v>
+                              </d>
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">99</v>
+                            <v n="TypeNodeIdLong">87295452L</v>
+                            <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                        </l>
+                        <o n="TypeNodeType" t="TypeNodeType">
+                          <v n="TypeClass" t="TypeClass">Userdef</v>
+                          <v n="QualifiedName">"VisuStructReferenceList"</v>
+                          <v n="Name">"VisuStructReferenceList"</v>
+                        </o>
+                        <v n="TypeNodeName">"m_References"</v>
+                        <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                          <v n="AttrFlags">81920UL</v>
+                          <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                            <v>DisplayFrameReferencesConfiguration</v>
+                            <v></v>
+                            <v>DescriptionTextId</v>
+                            <v>TL_ElementProperties.Desc_ReferencedVisus</v>
+                            <v>SortFlag</v>
+                            <v>80</v>
+                            <v>AssignDestination</v>
+                            <v>Init</v>
+                            <v>Category</v>
+                            <v>Simple|Standard</v>
+                            <v>DynamicArray</v>
+                            <v></v>
+                            <v>conditionalshow</v>
+                            <v>visu_elemdev</v>
+                            <v>FrameReferences</v>
+                            <v></v>
+                            <v>DisplayTextId</v>
+                            <v>TL_ElementProperties.References</v>
+                            <v>Storable</v>
+                            <v>True</v>
+                          </d>
+                          <v n="ConvDone">true</v>
+                        </o>
+                        <v n="TypeNodeId" t="Int16">97</v>
+                        <v n="TypeNodeIdLong">363316305L</v>
+                        <v n="LibraryId">"visuelems, 3.5.13.40 (system)"</v>
+                        <v n="DisplayTextId">"TL_ElementProperties.References"</v>
+                        <v n="DescriptionTextID">"TL_ElementProperties.Desc_ReferencedVisus"</v>
+                        <v n="DescriptionUseParent">false</v>
+                      </o>
+                    </o>
+                    <o>
+                      <v n="Id">3729828405L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                        <o>
+                          <v n="FontStyle">0</v>
+                          <v n="AdditionalFontStyle" t="UInt16">0</v>
+                          <v n="ExplicitColor">-16777216</v>
+                          <v n="CanonicalName">"Font-Standard"</v>
+                          <v n="FontName">"Arial"</v>
+                          <v n="FontSize">12</v>
+                          <v n="ScriptIdentification">0</v>
+                          <v n="DoubleFontSize" t="Double">0</v>
+                          <o n="NamedColor" t="NamedStyleColor">
+                            <v n="Color">-16777216</v>
+                            <v n="CanonicalName">"Font-Default-Color"</v>
+                          </o>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">550940142L</v>
+                      <v n="Value">264</v>
+                    </o>
+                    <o>
+                      <v n="Id">1473355128L</v>
+                      <v n="Value">207</v>
+                    </o>
+                    <o>
+                      <v n="Id">493260384L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">135947015L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">390574330L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2473092364L</v>
+                      <o n="Value" t="VisualizationNode">
+                        <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                        <n n="VisuNodeReference" />
+                        <v n="VisNodeRefs33">"lcls_twincat_motion.VISU_MotionStage"</v>
+                        <l n="TypeNodeChildren" t="ArrayList" cet="BasicTypeNode">
+                          <o>
+                            <v n="Flags">2L</v>
+                            <v n="BasicTypeNodeValue">"Main.M1"</v>
+                            <v n="BasicTypeNodeAcceptsExpression">true</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Reference</v>
+                              <v n="QualifiedName">"DUT_MotionStage"</v>
+                              <v n="Name">"DUT_MotionStage"</v>
+                            </o>
+                            <v n="TypeNodeName">"VisuMotionStage"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">0UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">255</v>
+                            <v n="TypeNodeIdLong">4223995186L</v>
+                            <n n="LibraryId" />
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                          <o>
+                            <v n="Flags">2L</v>
+                            <v n="BasicTypeNodeValue">"Main.stM1Extra"</v>
+                            <v n="BasicTypeNodeAcceptsExpression">true</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Reference</v>
+                              <v n="QualifiedName">"DUT_MotionStage_Extras"</v>
+                              <v n="Name">"DUT_MotionStage_Extras"</v>
+                            </o>
+                            <v n="TypeNodeName">"Extras"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">0UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">256</v>
+                            <v n="TypeNodeIdLong">188078752L</v>
+                            <n n="LibraryId" />
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                        </l>
+                        <o n="TypeNodeType" t="TypeNodeType">
+                          <v n="TypeClass" t="TypeClass">Userdef</v>
+                          <v n="QualifiedName">"IVisualisation"</v>
+                          <v n="Name">"IVisualisation"</v>
+                        </o>
+                        <v n="TypeNodeName">"[0]"</v>
+                        <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                          <v n="AttrFlags">0UL</v>
+                          <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                            <v>ieccodeconversion_useexistinginterface</v>
+                            <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                            <v>conditionalshow</v>
+                            <v>visu_elemdev</v>
+                            <v>''NORMAL__COMMENT</v>
+                            <v> interface contains additional methods to IVisualElement</v>
+                          </d>
+                          <v n="ConvDone">true</v>
+                        </o>
+                        <v n="TypeNodeId" t="Int16">1</v>
+                        <v n="TypeNodeIdLong">2473092364L</v>
+                        <n n="LibraryId" />
+                        <n n="DisplayTextId" />
+                        <n n="DescriptionTextID" />
+                        <v n="DescriptionUseParent">false</v>
+                      </o>
+                    </o>
+                    <o>
+                      <v n="Id">2597686782L</v>
+                      <v n="Value">true</v>
+                    </o>
+                    <o>
+                      <v n="Id">4223995186L</v>
+                      <v n="Value">"Main.M1"</v>
+                    </o>
+                    <o>
+                      <v n="Id">188078752L</v>
+                      <v n="Value">"Main.stM1Extra"</v>
+                    </o>
+                  </l>
+                </o>
+                <v n="VisualElementName">"Frame"</v>
+                <v n="VisualElementTypeName">"VisuFbFrame"</v>
+                <v n="VisualElementIsRectangle">true</v>
+                <v n="VisualElementIdentifier">"GenElemInst_2"</v>
+                <n n="VisualElementOfflinePaintCommands" />
+                <o n="VisualElementFrameInformation" t="VisualFrameInfo">
+                  <l n="ContainedGuids" t="ArrayList" />
+                  <l n="ContainedVisualizations" t="ArrayList" />
+                  <a n="ContainedVisualizations33" cet="String">
+                    <v>lcls_twincat_motion.VISU_MotionStage</v>
+                  </a>
+                </o>
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{1c47d03d-08a6-43ff-9c97-aaac1cda818b}</v>
+                <v n="VisualElementOwningObjectGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+                <a n="LMGuids" et="Guid" />
+                <d n="SubElements" t="Hashtable" />
+                <v n="VisualElementId">2</v>
+                <l n="UserManagementAccessRights" t="ArrayList" />
+              </o>
+              <o>
+                <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                <l n="Elements" t="ArrayList" />
+                <n n="VisualElementDescription" />
+                <o n="VisualElemMemberList" t="VisualElemMemberList">
+                  <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                    <o>
+                      <v n="Id">2340015797L</v>
+                      <v n="Value">"HCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2565699834L</v>
+                      <v n="Value">"VCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4134387352L</v>
+                      <v n="Value">"NONE"</v>
+                    </o>
+                    <o>
+                      <v n="Id">1603690730L</v>
+                      <v n="Value">"Arial"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4253639993L</v>
+                      <v n="Value" t="Int16">12</v>
+                    </o>
+                    <o>
+                      <v n="Id">2729990903L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1213979116L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3488306084L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">2812299069L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">494569607L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3719097617L</v>
+                      <v n="Value">0</v>
+                    </o>
+                    <o>
+                      <v n="Id">1649127785L</v>
+                      <v n="Value">189</v>
+                    </o>
+                    <o>
+                      <v n="Id">357335551L</v>
+                      <v n="Value">47</v>
+                    </o>
+                    <o>
+                      <v n="Id">2422045748L</v>
+                      <v n="Value">150</v>
+                    </o>
+                    <o>
+                      <v n="Id">2134141914L</v>
+                      <v n="Value">30</v>
+                    </o>
+                    <o>
+                      <v n="Id">390574330L</v>
+                      <v n="Value">"M1"</v>
+                    </o>
+                    <o>
+                      <v n="Id">3729828405L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                        <o>
+                          <v n="FontStyle">1</v>
+                          <v n="AdditionalFontStyle" t="UInt16">0</v>
+                          <v n="ExplicitColor">-16777216</v>
+                          <v n="CanonicalName">"Font-Title"</v>
+                          <v n="FontName">"Segoe UI"</v>
+                          <v n="FontSize">40</v>
+                          <v n="ScriptIdentification">0</v>
+                          <v n="DoubleFontSize" t="Double">0</v>
+                          <o n="NamedColor" t="NamedStyleColor">
+                            <v n="Color">-16777216</v>
+                            <v n="CanonicalName">"Font-Default-Color"</v>
+                          </o>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">493260384L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">135947015L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">2678395525L</v>
+                      <v n="Value">1U</v>
+                    </o>
+                    <o>
+                      <v n="Id">571893170L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2597686782L</v>
+                      <v n="Value">true</v>
+                    </o>
+                    <o>
+                      <v n="Id">823443203L</v>
+                      <v n="Value">"456"</v>
+                    </o>
+                  </l>
+                </o>
+                <v n="VisualElementName">"Label"</v>
+                <v n="VisualElementTypeName">"VisuFbLabel"</v>
+                <v n="VisualElementIsRectangle">true</v>
+                <v n="VisualElementIdentifier">"GenElemInst_3"</v>
+                <n n="VisualElementOfflinePaintCommands" />
+                <n n="VisualElementFrameInformation" />
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{a7820caf-cc3b-4630-9307-126539f4cf4b}</v>
+                <v n="VisualElementOwningObjectGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+                <a n="LMGuids" et="Guid" />
+                <d n="SubElements" t="Hashtable" />
+                <v n="VisualElementId">3</v>
+                <l n="UserManagementAccessRights" t="ArrayList" />
+              </o>
+              <o>
+                <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                <l n="Elements" t="ArrayList" />
+                <n n="VisualElementDescription" />
+                <o n="VisualElemMemberList" t="VisualElemMemberList">
+                  <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                    <o>
+                      <v n="Id">571893170L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2341735680L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                        <o>
+                          <v n="Color">-2830136</v>
+                          <v n="CanonicalName">"Element-Frame-Color"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">438423234L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                        <o>
+                          <v n="Color">-65536</v>
+                          <v n="CanonicalName">"Element-Alarm-Frame-Color"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">2678395525L</v>
+                      <v n="Value" t="Int16">1</v>
+                    </o>
+                    <o>
+                      <v n="Id">2340015797L</v>
+                      <v n="Value">"HCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2565699834L</v>
+                      <v n="Value">"VCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4134387352L</v>
+                      <v n="Value">"NONE"</v>
+                    </o>
+                    <o>
+                      <v n="Id">1603690730L</v>
+                      <v n="Value">"Arial"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4253639993L</v>
+                      <v n="Value" t="Int16">12</v>
+                    </o>
+                    <o>
+                      <v n="Id">2729990903L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1213979116L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3488306084L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1999528970L</v>
+                      <v n="Value">"&lt;toggle/tap variable&gt;"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2812299069L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">494569607L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3719097617L</v>
+                      <v n="Value">0</v>
+                    </o>
+                    <o>
+                      <v n="Id">1649127785L</v>
+                      <v n="Value">529</v>
+                    </o>
+                    <o>
+                      <v n="Id">357335551L</v>
+                      <v n="Value">57</v>
+                    </o>
+                    <o>
+                      <v n="Id">2422045748L</v>
+                      <v n="Value">520</v>
+                    </o>
+                    <o>
+                      <v n="Id">2134141914L</v>
+                      <v n="Value">300</v>
+                    </o>
+                    <o>
+                      <v n="Id">394923068L</v>
+                      <v n="Value">false</v>
+                    </o>
+                    <o>
+                      <v n="Id">2322377816L</v>
+                      <v n="Value">"NO_FRAME"</v>
+                    </o>
+                    <o>
+                      <v n="Id">3549563837L</v>
+                      <v n="Value">"ANISOTROPIC"</v>
+                    </o>
+                    <o>
+                      <v n="Id">363316305L</v>
+                      <o n="Value" t="StructuredTypeNode">
+                        <v n="StructuredTypeNodeIsAnimation">false</v>
+                        <l n="TypeNodeChildren" t="ArrayList">
+                          <o t="DynamicArrayNode">
+                            <o n="DynamicArrayNodeCounterNode" t="BasicTypeNode">
+                              <v n="Flags">0L</v>
+                              <v n="BasicTypeNodeValue" t="Int16">1</v>
+                              <v n="BasicTypeNodeAcceptsExpression">false</v>
+                              <n n="BasicTypeNodeFastAccess" />
+                              <a n="BasicTypeNodeEnumValues" et="String" />
+                              <n n="EnumValueDisplayTextIds" />
+                              <n n="EnumValueVisibilityAttributeValues" />
+                              <n n="EnumValueLibraryId" />
+                              <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                              <l n="TypeNodeChildren" t="ArrayList" />
+                              <o n="TypeNodeType" t="TypeNodeType">
+                                <v n="TypeClass" t="TypeClass">Int</v>
+                                <v n="QualifiedName">"INT"</v>
+                                <v n="Name">"INT"</v>
+                              </o>
+                              <v n="TypeNodeName">"iCount"</v>
+                              <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                <v n="AttrFlags">1UL</v>
+                                <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                  <v>Visible</v>
+                                  <v>False</v>
+                                </d>
+                                <v n="ConvDone">true</v>
+                              </o>
+                              <v n="TypeNodeId" t="Int16">99</v>
+                              <v n="TypeNodeIdLong">87295452L</v>
+                              <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                              <n n="DisplayTextId" />
+                              <n n="DescriptionTextID" />
+                              <v n="DescriptionUseParent">false</v>
+                            </o>
+                            <n n="DynamicArrayNodeFastAccess" />
+                            <o n="ChildTemplate" t="VisualizationNode">
+                              <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                              <n n="VisuNodeReference" />
+                              <n n="VisNodeRefs33" />
+                              <l n="TypeNodeChildren" t="ArrayList" />
+                              <o n="TypeNodeType" t="TypeNodeType">
+                                <v n="TypeClass" t="TypeClass">Userdef</v>
+                                <v n="QualifiedName">"IVisualisation"</v>
+                                <v n="Name">"IVisualisation"</v>
+                              </o>
+                              <v n="TypeNodeName">""</v>
+                              <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                <v n="AttrFlags">0UL</v>
+                                <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                  <v>ieccodeconversion_useexistinginterface</v>
+                                  <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                                  <v>conditionalshow</v>
+                                  <v>visu_elemdev</v>
+                                  <v>''NORMAL__COMMENT</v>
+                                  <v> interface contains additional methods to IVisualElement</v>
+                                </d>
+                                <v n="ConvDone">true</v>
+                              </o>
+                              <v n="TypeNodeId" t="Int16">1</v>
+                              <v n="TypeNodeIdLong">3861935604L</v>
+                              <n n="LibraryId" />
+                              <n n="DisplayTextId" />
+                              <n n="DescriptionTextID" />
+                              <v n="DescriptionUseParent">false</v>
+                            </o>
+                            <l n="TypeNodeChildren" t="ArrayList" cet="VisualizationNode">
+                              <o>
+                                <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                                <n n="VisuNodeReference" />
+                                <v n="VisNodeRefs33">"lcls_twincat_motion.VISU_MotionStage"</v>
+                                <l n="TypeNodeChildren" t="ArrayList" cet="BasicTypeNode">
+                                  <o>
+                                    <v n="Flags">2L</v>
+                                    <n n="BasicTypeNodeValue" />
+                                    <v n="BasicTypeNodeAcceptsExpression">true</v>
+                                    <n n="BasicTypeNodeFastAccess" />
+                                    <a n="BasicTypeNodeEnumValues" et="String" />
+                                    <n n="EnumValueDisplayTextIds" />
+                                    <n n="EnumValueVisibilityAttributeValues" />
+                                    <n n="EnumValueLibraryId" />
+                                    <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                                    <l n="TypeNodeChildren" t="ArrayList" />
+                                    <o n="TypeNodeType" t="TypeNodeType">
+                                      <v n="TypeClass" t="TypeClass">Reference</v>
+                                      <v n="QualifiedName">"DUT_MotionStage"</v>
+                                      <v n="Name">"DUT_MotionStage"</v>
+                                    </o>
+                                    <v n="TypeNodeName">"VisuMotionStage"</v>
+                                    <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                      <v n="AttrFlags">0UL</v>
+                                      <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                                      <v n="ConvDone">true</v>
+                                    </o>
+                                    <v n="TypeNodeId" t="Int16">255</v>
+                                    <v n="TypeNodeIdLong">4223995186L</v>
+                                    <n n="LibraryId" />
+                                    <n n="DisplayTextId" />
+                                    <n n="DescriptionTextID" />
+                                    <v n="DescriptionUseParent">false</v>
+                                  </o>
+                                  <o>
+                                    <v n="Flags">2L</v>
+                                    <n n="BasicTypeNodeValue" />
+                                    <v n="BasicTypeNodeAcceptsExpression">true</v>
+                                    <n n="BasicTypeNodeFastAccess" />
+                                    <a n="BasicTypeNodeEnumValues" et="String" />
+                                    <n n="EnumValueDisplayTextIds" />
+                                    <n n="EnumValueVisibilityAttributeValues" />
+                                    <n n="EnumValueLibraryId" />
+                                    <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                                    <l n="TypeNodeChildren" t="ArrayList" />
+                                    <o n="TypeNodeType" t="TypeNodeType">
+                                      <v n="TypeClass" t="TypeClass">Reference</v>
+                                      <v n="QualifiedName">"DUT_MotionStage_Extras"</v>
+                                      <v n="Name">"DUT_MotionStage_Extras"</v>
+                                    </o>
+                                    <v n="TypeNodeName">"Extras"</v>
+                                    <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                      <v n="AttrFlags">0UL</v>
+                                      <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                                      <v n="ConvDone">true</v>
+                                    </o>
+                                    <v n="TypeNodeId" t="Int16">256</v>
+                                    <v n="TypeNodeIdLong">188078752L</v>
+                                    <n n="LibraryId" />
+                                    <n n="DisplayTextId" />
+                                    <n n="DescriptionTextID" />
+                                    <v n="DescriptionUseParent">false</v>
+                                  </o>
+                                </l>
+                                <o n="TypeNodeType" t="TypeNodeType">
+                                  <v n="TypeClass" t="TypeClass">Userdef</v>
+                                  <v n="QualifiedName">"IVisualisation"</v>
+                                  <v n="Name">"IVisualisation"</v>
+                                </o>
+                                <v n="TypeNodeName">"[0]"</v>
+                                <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                  <v n="AttrFlags">0UL</v>
+                                  <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                    <v>ieccodeconversion_useexistinginterface</v>
+                                    <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                                    <v>conditionalshow</v>
+                                    <v>visu_elemdev</v>
+                                    <v>''NORMAL__COMMENT</v>
+                                    <v> interface contains additional methods to IVisualElement</v>
+                                  </d>
+                                  <v n="ConvDone">true</v>
+                                </o>
+                                <v n="TypeNodeId" t="Int16">1</v>
+                                <v n="TypeNodeIdLong">2473092364L</v>
+                                <n n="LibraryId" />
+                                <n n="DisplayTextId" />
+                                <n n="DescriptionTextID" />
+                                <v n="DescriptionUseParent">false</v>
+                              </o>
+                            </l>
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Userdef</v>
+                              <v n="QualifiedName">"IVisualisation"</v>
+                              <v n="Name">"IVisualisation"</v>
+                            </o>
+                            <v n="TypeNodeName">"pReferences"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">1048577UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                <v>Visible</v>
+                                <v>False</v>
+                                <v>ieccodeconversion_array</v>
+                                <v></v>
+                                <v>VisibleChildren</v>
+                                <v>True</v>
+                                <v>DefaultArraySize</v>
+                                <v>5</v>
+                                <v>''NORMAL__COMMENT</v>
+                                <v> We hide this node to prevent having two References nodes
+ Nevertheless we want to make sure that the children are displayed</v>
+                              </d>
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">98</v>
+                            <v n="TypeNodeIdLong">1547928903L</v>
+                            <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                          <o t="BasicTypeNode">
+                            <v n="Flags">0L</v>
+                            <v n="BasicTypeNodeValue" t="Int16">1</v>
+                            <v n="BasicTypeNodeAcceptsExpression">false</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Int</v>
+                              <v n="QualifiedName">"INT"</v>
+                              <v n="Name">"INT"</v>
+                            </o>
+                            <v n="TypeNodeName">"iCount"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">1UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                <v>Visible</v>
+                                <v>False</v>
+                              </d>
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">99</v>
+                            <v n="TypeNodeIdLong">87295452L</v>
+                            <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                        </l>
+                        <o n="TypeNodeType" t="TypeNodeType">
+                          <v n="TypeClass" t="TypeClass">Userdef</v>
+                          <v n="QualifiedName">"VisuStructReferenceList"</v>
+                          <v n="Name">"VisuStructReferenceList"</v>
+                        </o>
+                        <v n="TypeNodeName">"m_References"</v>
+                        <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                          <v n="AttrFlags">81920UL</v>
+                          <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                            <v>conditionalshow</v>
+                            <v>visu_elemdev</v>
+                            <v>DescriptionTextId</v>
+                            <v>TL_ElementProperties.Desc_ReferencedVisus</v>
+                            <v>SortFlag</v>
+                            <v>80</v>
+                            <v>AssignDestination</v>
+                            <v>Init</v>
+                            <v>Category</v>
+                            <v>Simple|Standard</v>
+                            <v>DynamicArray</v>
+                            <v></v>
+                            <v>DisplayFrameReferencesConfiguration</v>
+                            <v></v>
+                            <v>FrameReferences</v>
+                            <v></v>
+                            <v>Storable</v>
+                            <v>True</v>
+                            <v>DisplayTextId</v>
+                            <v>TL_ElementProperties.References</v>
+                          </d>
+                          <v n="ConvDone">true</v>
+                        </o>
+                        <v n="TypeNodeId" t="Int16">97</v>
+                        <v n="TypeNodeIdLong">363316305L</v>
+                        <v n="LibraryId">"visuelems, 3.5.13.40 (system)"</v>
+                        <v n="DisplayTextId">"TL_ElementProperties.References"</v>
+                        <v n="DescriptionTextID">"TL_ElementProperties.Desc_ReferencedVisus"</v>
+                        <v n="DescriptionUseParent">false</v>
+                      </o>
+                    </o>
+                    <o>
+                      <v n="Id">3729828405L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                        <o>
+                          <v n="FontStyle">0</v>
+                          <v n="AdditionalFontStyle" t="UInt16">0</v>
+                          <v n="ExplicitColor">-16777216</v>
+                          <v n="CanonicalName">"Font-Standard"</v>
+                          <v n="FontName">"Arial"</v>
+                          <v n="FontSize">12</v>
+                          <v n="ScriptIdentification">0</v>
+                          <v n="DoubleFontSize" t="Double">0</v>
+                          <o n="NamedColor" t="NamedStyleColor">
+                            <v n="Color">-16777216</v>
+                            <v n="CanonicalName">"Font-Default-Color"</v>
+                          </o>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">550940142L</v>
+                      <v n="Value">789</v>
+                    </o>
+                    <o>
+                      <v n="Id">1473355128L</v>
+                      <v n="Value">207</v>
+                    </o>
+                    <o>
+                      <v n="Id">493260384L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">135947015L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">390574330L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2473092364L</v>
+                      <o n="Value" t="VisualizationNode">
+                        <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                        <n n="VisuNodeReference" />
+                        <v n="VisNodeRefs33">"lcls_twincat_motion.VISU_MotionStage"</v>
+                        <l n="TypeNodeChildren" t="ArrayList" cet="BasicTypeNode">
+                          <o>
+                            <v n="Flags">2L</v>
+                            <v n="BasicTypeNodeValue">"Main.M2"</v>
+                            <v n="BasicTypeNodeAcceptsExpression">true</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Reference</v>
+                              <v n="QualifiedName">"DUT_MotionStage"</v>
+                              <v n="Name">"DUT_MotionStage"</v>
+                            </o>
+                            <v n="TypeNodeName">"VisuMotionStage"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">0UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">255</v>
+                            <v n="TypeNodeIdLong">4223995186L</v>
+                            <n n="LibraryId" />
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                          <o>
+                            <v n="Flags">2L</v>
+                            <v n="BasicTypeNodeValue">"Main.stM2Extra"</v>
+                            <v n="BasicTypeNodeAcceptsExpression">true</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Reference</v>
+                              <v n="QualifiedName">"DUT_MotionStage_Extras"</v>
+                              <v n="Name">"DUT_MotionStage_Extras"</v>
+                            </o>
+                            <v n="TypeNodeName">"Extras"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">0UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">256</v>
+                            <v n="TypeNodeIdLong">188078752L</v>
+                            <n n="LibraryId" />
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                        </l>
+                        <o n="TypeNodeType" t="TypeNodeType">
+                          <v n="TypeClass" t="TypeClass">Userdef</v>
+                          <v n="QualifiedName">"IVisualisation"</v>
+                          <v n="Name">"IVisualisation"</v>
+                        </o>
+                        <v n="TypeNodeName">"[0]"</v>
+                        <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                          <v n="AttrFlags">0UL</v>
+                          <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                            <v>ieccodeconversion_useexistinginterface</v>
+                            <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                            <v>conditionalshow</v>
+                            <v>visu_elemdev</v>
+                            <v>''NORMAL__COMMENT</v>
+                            <v> interface contains additional methods to IVisualElement</v>
+                          </d>
+                          <v n="ConvDone">true</v>
+                        </o>
+                        <v n="TypeNodeId" t="Int16">1</v>
+                        <v n="TypeNodeIdLong">2473092364L</v>
+                        <n n="LibraryId" />
+                        <n n="DisplayTextId" />
+                        <n n="DescriptionTextID" />
+                        <v n="DescriptionUseParent">false</v>
+                      </o>
+                    </o>
+                    <o>
+                      <v n="Id">2597686782L</v>
+                      <v n="Value">true</v>
+                    </o>
+                    <o>
+                      <v n="Id">4223995186L</v>
+                      <v n="Value">"Main.M2"</v>
+                    </o>
+                    <o>
+                      <v n="Id">188078752L</v>
+                      <v n="Value">"Main.stM2Extra"</v>
+                    </o>
+                  </l>
+                </o>
+                <v n="VisualElementName">"Frame"</v>
+                <v n="VisualElementTypeName">"VisuFbFrame"</v>
+                <v n="VisualElementIsRectangle">true</v>
+                <v n="VisualElementIdentifier">"GenElemInst_5"</v>
+                <n n="VisualElementOfflinePaintCommands" />
+                <o n="VisualElementFrameInformation" t="VisualFrameInfo">
+                  <l n="ContainedGuids" t="ArrayList" />
+                  <l n="ContainedVisualizations" t="ArrayList" />
+                  <a n="ContainedVisualizations33" cet="String">
+                    <v>lcls_twincat_motion.VISU_MotionStage</v>
+                  </a>
+                </o>
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{b5def4ab-f9fe-46ba-9bfa-b898bea7b7a7}</v>
+                <v n="VisualElementOwningObjectGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+                <a n="LMGuids" et="Guid" />
+                <d n="SubElements" t="Hashtable" />
+                <v n="VisualElementId">5</v>
+                <l n="UserManagementAccessRights" t="ArrayList" />
+              </o>
+              <o>
+                <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                <l n="Elements" t="ArrayList" />
+                <n n="VisualElementDescription" />
+                <o n="VisualElemMemberList" t="VisualElemMemberList">
+                  <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                    <o>
+                      <v n="Id">2340015797L</v>
+                      <v n="Value">"HCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2565699834L</v>
+                      <v n="Value">"VCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4134387352L</v>
+                      <v n="Value">"NONE"</v>
+                    </o>
+                    <o>
+                      <v n="Id">1603690730L</v>
+                      <v n="Value">"Arial"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4253639993L</v>
+                      <v n="Value" t="Int16">12</v>
+                    </o>
+                    <o>
+                      <v n="Id">2729990903L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1213979116L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3488306084L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">2812299069L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">494569607L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3719097617L</v>
+                      <v n="Value">0</v>
+                    </o>
+                    <o>
+                      <v n="Id">1649127785L</v>
+                      <v n="Value">714</v>
+                    </o>
+                    <o>
+                      <v n="Id">357335551L</v>
+                      <v n="Value">47</v>
+                    </o>
+                    <o>
+                      <v n="Id">2422045748L</v>
+                      <v n="Value">150</v>
+                    </o>
+                    <o>
+                      <v n="Id">2134141914L</v>
+                      <v n="Value">30</v>
+                    </o>
+                    <o>
+                      <v n="Id">390574330L</v>
+                      <v n="Value">"M2"</v>
+                    </o>
+                    <o>
+                      <v n="Id">3729828405L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                        <o>
+                          <v n="FontStyle">1</v>
+                          <v n="AdditionalFontStyle" t="UInt16">0</v>
+                          <v n="ExplicitColor">-16777216</v>
+                          <v n="CanonicalName">"Font-Title"</v>
+                          <v n="FontName">"Segoe UI"</v>
+                          <v n="FontSize">40</v>
+                          <v n="ScriptIdentification">0</v>
+                          <v n="DoubleFontSize" t="Double">0</v>
+                          <o n="NamedColor" t="NamedStyleColor">
+                            <v n="Color">-16777216</v>
+                            <v n="CanonicalName">"Font-Default-Color"</v>
+                          </o>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">493260384L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">135947015L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">2678395525L</v>
+                      <v n="Value">1U</v>
+                    </o>
+                    <o>
+                      <v n="Id">571893170L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2597686782L</v>
+                      <v n="Value">true</v>
+                    </o>
+                    <o>
+                      <v n="Id">823443203L</v>
+                      <v n="Value">"114"</v>
+                    </o>
+                  </l>
+                </o>
+                <v n="VisualElementName">"Label"</v>
+                <v n="VisualElementTypeName">"VisuFbLabel"</v>
+                <v n="VisualElementIsRectangle">true</v>
+                <v n="VisualElementIdentifier">"GenElemInst_7"</v>
+                <n n="VisualElementOfflinePaintCommands" />
+                <n n="VisualElementFrameInformation" />
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{b8b381e3-53f3-48bf-aa3f-1ffddb091506}</v>
+                <v n="VisualElementOwningObjectGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+                <a n="LMGuids" et="Guid" />
+                <d n="SubElements" t="Hashtable" />
+                <v n="VisualElementId">7</v>
+                <l n="UserManagementAccessRights" t="ArrayList" />
+              </o>
+              <o>
+                <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                <l n="Elements" t="ArrayList" />
+                <n n="VisualElementDescription" />
+                <o n="VisualElemMemberList" t="VisualElemMemberList">
+                  <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                    <o>
+                      <v n="Id">571893170L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2341735680L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                        <o>
+                          <v n="Color">-2830136</v>
+                          <v n="CanonicalName">"Element-Frame-Color"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">438423234L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                        <o>
+                          <v n="Color">-65536</v>
+                          <v n="CanonicalName">"Element-Alarm-Frame-Color"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">2678395525L</v>
+                      <v n="Value" t="Int16">1</v>
+                    </o>
+                    <o>
+                      <v n="Id">2340015797L</v>
+                      <v n="Value">"HCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2565699834L</v>
+                      <v n="Value">"VCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4134387352L</v>
+                      <v n="Value">"NONE"</v>
+                    </o>
+                    <o>
+                      <v n="Id">1603690730L</v>
+                      <v n="Value">"Arial"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4253639993L</v>
+                      <v n="Value" t="Int16">12</v>
+                    </o>
+                    <o>
+                      <v n="Id">2729990903L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1213979116L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3488306084L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1999528970L</v>
+                      <v n="Value">"&lt;toggle/tap variable&gt;"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2812299069L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">494569607L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3719097617L</v>
+                      <v n="Value">0</v>
+                    </o>
+                    <o>
+                      <v n="Id">1649127785L</v>
+                      <v n="Value">1047</v>
+                    </o>
+                    <o>
+                      <v n="Id">357335551L</v>
+                      <v n="Value">57</v>
+                    </o>
+                    <o>
+                      <v n="Id">2422045748L</v>
+                      <v n="Value">520</v>
+                    </o>
+                    <o>
+                      <v n="Id">2134141914L</v>
+                      <v n="Value">300</v>
+                    </o>
+                    <o>
+                      <v n="Id">394923068L</v>
+                      <v n="Value">false</v>
+                    </o>
+                    <o>
+                      <v n="Id">2322377816L</v>
+                      <v n="Value">"NO_FRAME"</v>
+                    </o>
+                    <o>
+                      <v n="Id">3549563837L</v>
+                      <v n="Value">"ANISOTROPIC"</v>
+                    </o>
+                    <o>
+                      <v n="Id">363316305L</v>
+                      <o n="Value" t="StructuredTypeNode">
+                        <v n="StructuredTypeNodeIsAnimation">false</v>
+                        <l n="TypeNodeChildren" t="ArrayList">
+                          <o t="DynamicArrayNode">
+                            <o n="DynamicArrayNodeCounterNode" t="BasicTypeNode">
+                              <v n="Flags">0L</v>
+                              <v n="BasicTypeNodeValue" t="Int16">1</v>
+                              <v n="BasicTypeNodeAcceptsExpression">false</v>
+                              <n n="BasicTypeNodeFastAccess" />
+                              <a n="BasicTypeNodeEnumValues" et="String" />
+                              <n n="EnumValueDisplayTextIds" />
+                              <n n="EnumValueVisibilityAttributeValues" />
+                              <n n="EnumValueLibraryId" />
+                              <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                              <l n="TypeNodeChildren" t="ArrayList" />
+                              <o n="TypeNodeType" t="TypeNodeType">
+                                <v n="TypeClass" t="TypeClass">Int</v>
+                                <v n="QualifiedName">"INT"</v>
+                                <v n="Name">"INT"</v>
+                              </o>
+                              <v n="TypeNodeName">"iCount"</v>
+                              <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                <v n="AttrFlags">1UL</v>
+                                <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                  <v>Visible</v>
+                                  <v>False</v>
+                                </d>
+                                <v n="ConvDone">true</v>
+                              </o>
+                              <v n="TypeNodeId" t="Int16">99</v>
+                              <v n="TypeNodeIdLong">87295452L</v>
+                              <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                              <n n="DisplayTextId" />
+                              <n n="DescriptionTextID" />
+                              <v n="DescriptionUseParent">false</v>
+                            </o>
+                            <n n="DynamicArrayNodeFastAccess" />
+                            <o n="ChildTemplate" t="VisualizationNode">
+                              <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                              <n n="VisuNodeReference" />
+                              <n n="VisNodeRefs33" />
+                              <l n="TypeNodeChildren" t="ArrayList" />
+                              <o n="TypeNodeType" t="TypeNodeType">
+                                <v n="TypeClass" t="TypeClass">Userdef</v>
+                                <v n="QualifiedName">"IVisualisation"</v>
+                                <v n="Name">"IVisualisation"</v>
+                              </o>
+                              <v n="TypeNodeName">""</v>
+                              <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                <v n="AttrFlags">0UL</v>
+                                <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                  <v>ieccodeconversion_useexistinginterface</v>
+                                  <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                                  <v>conditionalshow</v>
+                                  <v>visu_elemdev</v>
+                                  <v>''NORMAL__COMMENT</v>
+                                  <v> interface contains additional methods to IVisualElement</v>
+                                </d>
+                                <v n="ConvDone">true</v>
+                              </o>
+                              <v n="TypeNodeId" t="Int16">1</v>
+                              <v n="TypeNodeIdLong">3861935604L</v>
+                              <n n="LibraryId" />
+                              <n n="DisplayTextId" />
+                              <n n="DescriptionTextID" />
+                              <v n="DescriptionUseParent">false</v>
+                            </o>
+                            <l n="TypeNodeChildren" t="ArrayList" cet="VisualizationNode">
+                              <o>
+                                <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                                <n n="VisuNodeReference" />
+                                <v n="VisNodeRefs33">"lcls_twincat_motion.VISU_MotionStage"</v>
+                                <l n="TypeNodeChildren" t="ArrayList" cet="BasicTypeNode">
+                                  <o>
+                                    <v n="Flags">2L</v>
+                                    <n n="BasicTypeNodeValue" />
+                                    <v n="BasicTypeNodeAcceptsExpression">true</v>
+                                    <n n="BasicTypeNodeFastAccess" />
+                                    <a n="BasicTypeNodeEnumValues" et="String" />
+                                    <n n="EnumValueDisplayTextIds" />
+                                    <n n="EnumValueVisibilityAttributeValues" />
+                                    <n n="EnumValueLibraryId" />
+                                    <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                                    <l n="TypeNodeChildren" t="ArrayList" />
+                                    <o n="TypeNodeType" t="TypeNodeType">
+                                      <v n="TypeClass" t="TypeClass">Reference</v>
+                                      <v n="QualifiedName">"DUT_MotionStage"</v>
+                                      <v n="Name">"DUT_MotionStage"</v>
+                                    </o>
+                                    <v n="TypeNodeName">"VisuMotionStage"</v>
+                                    <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                      <v n="AttrFlags">0UL</v>
+                                      <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                                      <v n="ConvDone">true</v>
+                                    </o>
+                                    <v n="TypeNodeId" t="Int16">255</v>
+                                    <v n="TypeNodeIdLong">4223995186L</v>
+                                    <n n="LibraryId" />
+                                    <n n="DisplayTextId" />
+                                    <n n="DescriptionTextID" />
+                                    <v n="DescriptionUseParent">false</v>
+                                  </o>
+                                  <o>
+                                    <v n="Flags">2L</v>
+                                    <n n="BasicTypeNodeValue" />
+                                    <v n="BasicTypeNodeAcceptsExpression">true</v>
+                                    <n n="BasicTypeNodeFastAccess" />
+                                    <a n="BasicTypeNodeEnumValues" et="String" />
+                                    <n n="EnumValueDisplayTextIds" />
+                                    <n n="EnumValueVisibilityAttributeValues" />
+                                    <n n="EnumValueLibraryId" />
+                                    <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                                    <l n="TypeNodeChildren" t="ArrayList" />
+                                    <o n="TypeNodeType" t="TypeNodeType">
+                                      <v n="TypeClass" t="TypeClass">Reference</v>
+                                      <v n="QualifiedName">"DUT_MotionStage_Extras"</v>
+                                      <v n="Name">"DUT_MotionStage_Extras"</v>
+                                    </o>
+                                    <v n="TypeNodeName">"Extras"</v>
+                                    <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                      <v n="AttrFlags">0UL</v>
+                                      <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                                      <v n="ConvDone">true</v>
+                                    </o>
+                                    <v n="TypeNodeId" t="Int16">256</v>
+                                    <v n="TypeNodeIdLong">188078752L</v>
+                                    <n n="LibraryId" />
+                                    <n n="DisplayTextId" />
+                                    <n n="DescriptionTextID" />
+                                    <v n="DescriptionUseParent">false</v>
+                                  </o>
+                                </l>
+                                <o n="TypeNodeType" t="TypeNodeType">
+                                  <v n="TypeClass" t="TypeClass">Userdef</v>
+                                  <v n="QualifiedName">"IVisualisation"</v>
+                                  <v n="Name">"IVisualisation"</v>
+                                </o>
+                                <v n="TypeNodeName">"[0]"</v>
+                                <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                                  <v n="AttrFlags">0UL</v>
+                                  <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                    <v>ieccodeconversion_useexistinginterface</v>
+                                    <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                                    <v>conditionalshow</v>
+                                    <v>visu_elemdev</v>
+                                    <v>''NORMAL__COMMENT</v>
+                                    <v> interface contains additional methods to IVisualElement</v>
+                                  </d>
+                                  <v n="ConvDone">true</v>
+                                </o>
+                                <v n="TypeNodeId" t="Int16">1</v>
+                                <v n="TypeNodeIdLong">2473092364L</v>
+                                <n n="LibraryId" />
+                                <n n="DisplayTextId" />
+                                <n n="DescriptionTextID" />
+                                <v n="DescriptionUseParent">false</v>
+                              </o>
+                            </l>
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Userdef</v>
+                              <v n="QualifiedName">"IVisualisation"</v>
+                              <v n="Name">"IVisualisation"</v>
+                            </o>
+                            <v n="TypeNodeName">"pReferences"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">1048577UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                <v>Visible</v>
+                                <v>False</v>
+                                <v>ieccodeconversion_array</v>
+                                <v></v>
+                                <v>VisibleChildren</v>
+                                <v>True</v>
+                                <v>DefaultArraySize</v>
+                                <v>5</v>
+                                <v>''NORMAL__COMMENT</v>
+                                <v> We hide this node to prevent having two References nodes
+ Nevertheless we want to make sure that the children are displayed</v>
+                              </d>
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">98</v>
+                            <v n="TypeNodeIdLong">1547928903L</v>
+                            <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                          <o t="BasicTypeNode">
+                            <v n="Flags">0L</v>
+                            <v n="BasicTypeNodeValue" t="Int16">1</v>
+                            <v n="BasicTypeNodeAcceptsExpression">false</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Int</v>
+                              <v n="QualifiedName">"INT"</v>
+                              <v n="Name">"INT"</v>
+                            </o>
+                            <v n="TypeNodeName">"iCount"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">1UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                                <v>Visible</v>
+                                <v>False</v>
+                              </d>
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">99</v>
+                            <v n="TypeNodeIdLong">87295452L</v>
+                            <v n="LibraryId">"visuelembase, 3.5.13.40 (system)"</v>
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                        </l>
+                        <o n="TypeNodeType" t="TypeNodeType">
+                          <v n="TypeClass" t="TypeClass">Userdef</v>
+                          <v n="QualifiedName">"VisuStructReferenceList"</v>
+                          <v n="Name">"VisuStructReferenceList"</v>
+                        </o>
+                        <v n="TypeNodeName">"m_References"</v>
+                        <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                          <v n="AttrFlags">81920UL</v>
+                          <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                            <v>conditionalshow</v>
+                            <v>visu_elemdev</v>
+                            <v>DescriptionTextId</v>
+                            <v>TL_ElementProperties.Desc_ReferencedVisus</v>
+                            <v>SortFlag</v>
+                            <v>80</v>
+                            <v>AssignDestination</v>
+                            <v>Init</v>
+                            <v>Category</v>
+                            <v>Simple|Standard</v>
+                            <v>DynamicArray</v>
+                            <v></v>
+                            <v>DisplayFrameReferencesConfiguration</v>
+                            <v></v>
+                            <v>FrameReferences</v>
+                            <v></v>
+                            <v>Storable</v>
+                            <v>True</v>
+                            <v>DisplayTextId</v>
+                            <v>TL_ElementProperties.References</v>
+                          </d>
+                          <v n="ConvDone">true</v>
+                        </o>
+                        <v n="TypeNodeId" t="Int16">97</v>
+                        <v n="TypeNodeIdLong">363316305L</v>
+                        <v n="LibraryId">"visuelems, 3.5.13.40 (system)"</v>
+                        <v n="DisplayTextId">"TL_ElementProperties.References"</v>
+                        <v n="DescriptionTextID">"TL_ElementProperties.Desc_ReferencedVisus"</v>
+                        <v n="DescriptionUseParent">false</v>
+                      </o>
+                    </o>
+                    <o>
+                      <v n="Id">3729828405L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                        <o>
+                          <v n="FontStyle">0</v>
+                          <v n="AdditionalFontStyle" t="UInt16">0</v>
+                          <v n="ExplicitColor">-16777216</v>
+                          <v n="CanonicalName">"Font-Standard"</v>
+                          <v n="FontName">"Arial"</v>
+                          <v n="FontSize">12</v>
+                          <v n="ScriptIdentification">0</v>
+                          <v n="DoubleFontSize" t="Double">0</v>
+                          <o n="NamedColor" t="NamedStyleColor">
+                            <v n="Color">-16777216</v>
+                            <v n="CanonicalName">"Font-Default-Color"</v>
+                          </o>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">550940142L</v>
+                      <v n="Value">1307</v>
+                    </o>
+                    <o>
+                      <v n="Id">1473355128L</v>
+                      <v n="Value">207</v>
+                    </o>
+                    <o>
+                      <v n="Id">493260384L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">135947015L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">390574330L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2473092364L</v>
+                      <o n="Value" t="VisualizationNode">
+                        <v n="VisuNodeReferenceGuid">{00000000-0000-0000-0000-000000000000}</v>
+                        <n n="VisuNodeReference" />
+                        <v n="VisNodeRefs33">"lcls_twincat_motion.VISU_MotionStage"</v>
+                        <l n="TypeNodeChildren" t="ArrayList" cet="BasicTypeNode">
+                          <o>
+                            <v n="Flags">2L</v>
+                            <v n="BasicTypeNodeValue">"Main.M3"</v>
+                            <v n="BasicTypeNodeAcceptsExpression">true</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Reference</v>
+                              <v n="QualifiedName">"DUT_MotionStage"</v>
+                              <v n="Name">"DUT_MotionStage"</v>
+                            </o>
+                            <v n="TypeNodeName">"VisuMotionStage"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">0UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">255</v>
+                            <v n="TypeNodeIdLong">4223995186L</v>
+                            <n n="LibraryId" />
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                          <o>
+                            <v n="Flags">2L</v>
+                            <v n="BasicTypeNodeValue">"Main.stM3Extra"</v>
+                            <v n="BasicTypeNodeAcceptsExpression">true</v>
+                            <n n="BasicTypeNodeFastAccess" />
+                            <a n="BasicTypeNodeEnumValues" et="String" />
+                            <n n="EnumValueDisplayTextIds" />
+                            <n n="EnumValueVisibilityAttributeValues" />
+                            <n n="EnumValueLibraryId" />
+                            <n n="DynamicEnumMemberVisibilityCheckerTypeGuid" />
+                            <l n="TypeNodeChildren" t="ArrayList" />
+                            <o n="TypeNodeType" t="TypeNodeType">
+                              <v n="TypeClass" t="TypeClass">Reference</v>
+                              <v n="QualifiedName">"DUT_MotionStage_Extras"</v>
+                              <v n="Name">"DUT_MotionStage_Extras"</v>
+                            </o>
+                            <v n="TypeNodeName">"Extras"</v>
+                            <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                              <v n="AttrFlags">0UL</v>
+                              <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" />
+                              <v n="ConvDone">true</v>
+                            </o>
+                            <v n="TypeNodeId" t="Int16">256</v>
+                            <v n="TypeNodeIdLong">188078752L</v>
+                            <n n="LibraryId" />
+                            <n n="DisplayTextId" />
+                            <n n="DescriptionTextID" />
+                            <v n="DescriptionUseParent">false</v>
+                          </o>
+                        </l>
+                        <o n="TypeNodeType" t="TypeNodeType">
+                          <v n="TypeClass" t="TypeClass">Userdef</v>
+                          <v n="QualifiedName">"IVisualisation"</v>
+                          <v n="Name">"IVisualisation"</v>
+                        </o>
+                        <v n="TypeNodeName">"[0]"</v>
+                        <o n="TypeNodeAttributes" t="TypeNodeAttributes2">
+                          <v n="AttrFlags">0UL</v>
+                          <d n="TypeNodeAttributesData" t="CaseInsensitiveHashtable" ckt="String" cvt="String">
+                            <v>ieccodeconversion_useexistinginterface</v>
+                            <v>_3S.CoDeSys.VisuGenerated.IVisualisationIEC</v>
+                            <v>conditionalshow</v>
+                            <v>visu_elemdev</v>
+                            <v>''NORMAL__COMMENT</v>
+                            <v> interface contains additional methods to IVisualElement</v>
+                          </d>
+                          <v n="ConvDone">true</v>
+                        </o>
+                        <v n="TypeNodeId" t="Int16">1</v>
+                        <v n="TypeNodeIdLong">2473092364L</v>
+                        <n n="LibraryId" />
+                        <n n="DisplayTextId" />
+                        <n n="DescriptionTextID" />
+                        <v n="DescriptionUseParent">false</v>
+                      </o>
+                    </o>
+                    <o>
+                      <v n="Id">2597686782L</v>
+                      <v n="Value">true</v>
+                    </o>
+                    <o>
+                      <v n="Id">4223995186L</v>
+                      <v n="Value">"Main.M3"</v>
+                    </o>
+                    <o>
+                      <v n="Id">188078752L</v>
+                      <v n="Value">"Main.stM3Extra"</v>
+                    </o>
+                  </l>
+                </o>
+                <v n="VisualElementName">"Frame"</v>
+                <v n="VisualElementTypeName">"VisuFbFrame"</v>
+                <v n="VisualElementIsRectangle">true</v>
+                <v n="VisualElementIdentifier">"GenElemInst_9"</v>
+                <n n="VisualElementOfflinePaintCommands" />
+                <o n="VisualElementFrameInformation" t="VisualFrameInfo">
+                  <l n="ContainedGuids" t="ArrayList" />
+                  <l n="ContainedVisualizations" t="ArrayList" />
+                  <a n="ContainedVisualizations33" cet="String">
+                    <v>lcls_twincat_motion.VISU_MotionStage</v>
+                  </a>
+                </o>
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{67050c2f-958b-4f6e-94ca-69b4f2943128}</v>
+                <v n="VisualElementOwningObjectGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+                <a n="LMGuids" et="Guid" />
+                <d n="SubElements" t="Hashtable" />
+                <v n="VisualElementId">9</v>
+                <l n="UserManagementAccessRights" t="ArrayList" />
+              </o>
+              <o>
+                <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                <l n="Elements" t="ArrayList" />
+                <n n="VisualElementDescription" />
+                <o n="VisualElemMemberList" t="VisualElemMemberList">
+                  <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                    <o>
+                      <v n="Id">2340015797L</v>
+                      <v n="Value">"HCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">2565699834L</v>
+                      <v n="Value">"VCENTER"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4134387352L</v>
+                      <v n="Value">"NONE"</v>
+                    </o>
+                    <o>
+                      <v n="Id">1603690730L</v>
+                      <v n="Value">"Arial"</v>
+                    </o>
+                    <o>
+                      <v n="Id">4253639993L</v>
+                      <v n="Value" t="Int16">12</v>
+                    </o>
+                    <o>
+                      <v n="Id">2729990903L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">1213979116L</v>
+                      <v n="Value">0U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3488306084L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">2812299069L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">494569607L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">3719097617L</v>
+                      <v n="Value">0</v>
+                    </o>
+                    <o>
+                      <v n="Id">1649127785L</v>
+                      <v n="Value">1232</v>
+                    </o>
+                    <o>
+                      <v n="Id">357335551L</v>
+                      <v n="Value">47</v>
+                    </o>
+                    <o>
+                      <v n="Id">2422045748L</v>
+                      <v n="Value">150</v>
+                    </o>
+                    <o>
+                      <v n="Id">2134141914L</v>
+                      <v n="Value">30</v>
+                    </o>
+                    <o>
+                      <v n="Id">390574330L</v>
+                      <v n="Value">"M3"</v>
+                    </o>
+                    <o>
+                      <v n="Id">3729828405L</v>
+                      <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                        <o>
+                          <v n="FontStyle">1</v>
+                          <v n="AdditionalFontStyle" t="UInt16">0</v>
+                          <v n="ExplicitColor">-16777216</v>
+                          <v n="CanonicalName">"Font-Title"</v>
+                          <v n="FontName">"Segoe UI"</v>
+                          <v n="FontSize">40</v>
+                          <v n="ScriptIdentification">0</v>
+                          <v n="DoubleFontSize" t="Double">0</v>
+                          <o n="NamedColor" t="NamedStyleColor">
+                            <v n="Color">-16777216</v>
+                            <v n="CanonicalName">"Font-Default-Color"</v>
+                          </o>
+                        </o>
+                      </l>
+                    </o>
+                    <o>
+                      <v n="Id">493260384L</v>
+                      <v n="Value">4294967295U</v>
+                    </o>
+                    <o>
+                      <v n="Id">135947015L</v>
+                      <v n="Value">4278190080U</v>
+                    </o>
+                    <o>
+                      <v n="Id">2678395525L</v>
+                      <v n="Value">1U</v>
+                    </o>
+                    <o>
+                      <v n="Id">571893170L</v>
+                      <v n="Value">""</v>
+                    </o>
+                    <o>
+                      <v n="Id">2597686782L</v>
+                      <v n="Value">true</v>
+                    </o>
+                    <o>
+                      <v n="Id">823443203L</v>
+                      <v n="Value">"184"</v>
+                    </o>
+                  </l>
+                </o>
+                <v n="VisualElementName">"Label"</v>
+                <v n="VisualElementTypeName">"VisuFbLabel"</v>
+                <v n="VisualElementIsRectangle">true</v>
+                <v n="VisualElementIdentifier">"GenElemInst_11"</v>
+                <n n="VisualElementOfflinePaintCommands" />
+                <n n="VisualElementFrameInformation" />
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{e82bf273-c391-45db-acb3-21a085219f07}</v>
+                <v n="VisualElementOwningObjectGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+                <a n="LMGuids" et="Guid" />
+                <d n="SubElements" t="Hashtable" />
+                <v n="VisualElementId">11</v>
+                <l n="UserManagementAccessRights" t="ArrayList" />
+              </o>
+            </l>
+            <v n="BackgroundBitmapId">""</v>
+            <v n="BackgroundColor">16777215</v>
+            <o n="Background" t="BackgroundSettings">
+              <n n="BgGradient" />
+              <n n="BgNamedColor" />
+              <v n="BgBmpId">""</v>
+              <v n="BgUseBmp">false</v>
+              <v n="BgColor">false</v>
+              <v n="BgUseColor">16777215</v>
+              <v n="BgUseGradient">false</v>
+            </o>
+          </o>
+          <o n="GeneratedLMMDescriptions" t="GeneratedLanguageModelEntriesData">
+            <o n="GeneratedVisuFbDescription" t="GenericFbDescription">
+              <d n="FbMethods" t="CaseInsensitiveHashtable_1" ckt="String" cvt="Guid">
+                <v>GetUpdateRects</v>
+                <v>a2510bcb-387c-41a6-ad2f-e79a9a641e8b</v>
+                <v>ContainsPoint</v>
+                <v>83be9857-5469-40b0-8e3b-51e8a4b646e0</v>
+                <v>SetStaticState</v>
+                <v>82feb09f-0935-4741-9773-eb4cf53e1ab7</v>
+                <v>HasInputAccessIntern</v>
+                <v>4fbc4f2e-0fa1-4edf-9343-36e7ca4e78c2</v>
+                <v>GetTooltip</v>
+                <v>99f09c46-7ccc-4e58-be18-3c52376e0917</v>
+                <v>GetNamespace</v>
+                <v>402e4218-6904-4d0c-9ae0-a6d3ef5019e5</v>
+                <v>GetTranslator</v>
+                <v>bd065ba3-4686-44ba-9056-2769b534dcae</v>
+                <v>Update</v>
+                <v>ac567c6c-e8e2-41eb-8e92-abb00d11553e</v>
+                <v>SetClientData</v>
+                <v>1dc2dde7-7a71-4023-a50d-2607ce847606</v>
+                <v>GetClientData</v>
+                <v>35702a9f-6dbd-472a-aeb8-6449b7e0f333</v>
+                <v>Paint</v>
+                <v>ae7ad2a8-bacb-492b-8eff-61867118aa28</v>
+                <v>HasVisibilityAccess</v>
+                <v>883a21f0-55a3-4ef8-8f7a-12e10cdb2a4f</v>
+                <v>GetElementArray</v>
+                <v>351c9e36-e7ba-4aed-8f6e-e7bee53b4f57</v>
+                <v>SetVisuFlagsInternal</v>
+                <v>6b89b17b-5638-4ac6-98da-f1cc72268bcf</v>
+                <v>GetText</v>
+                <v>2ea2fde6-0778-4ee7-bd3c-22cff1dab611</v>
+                <v>GetTextProperties</v>
+                <v>c907cdfc-499d-43de-be5d-03de67e96271</v>
+                <v>IsAntialiasingInactive</v>
+                <v>35311ab4-7e7d-45c0-bca9-6151482609d1</v>
+                <v>Initialize</v>
+                <v>c846dc25-b95d-47cd-a7a3-9308ebb7cc4a</v>
+                <v>HasInputAccess</v>
+                <v>aea14f58-3f24-4603-9578-cb6563aa3531</v>
+                <v>HasVisibilityAccessIntern</v>
+                <v>82877f77-800f-42fd-93ca-3553aa3c177f</v>
+                <v>GetSurroundingRect</v>
+                <v>952ebe94-e933-490b-8755-f5bcc3d9a8f8</v>
+                <v>ElementInfo</v>
+                <v>e81204a6-d655-41ba-a709-2ba350a33b60</v>
+                <v>GetLocalUsergroup</v>
+                <v>bb6eba74-41d4-45ba-ab49-83390e998290</v>
+                <v>GetName</v>
+                <v>b3aa8033-6d12-402c-a47a-52b3bd3eefec</v>
+                <v>GetSize</v>
+                <v>24d7c62c-7351-459c-b022-378fb9d4ac91</v>
+                <v>FB_Reinit</v>
+                <v>9015e4cc-f458-457f-a833-b28f313d7bcd</v>
+                <v>FB_Exit</v>
+                <v>29160b37-579f-4640-a89d-17889cfa71e3</v>
+                <v>GetInitializeVersion</v>
+                <v>46c8a857-6f1d-4240-a733-1a6f2d4d731b</v>
+                <v>GetElementIdArray</v>
+                <v>262ad248-8738-4af7-9b34-0efb115b108c</v>
+                <v>HandleInput</v>
+                <v>93f450df-6b59-4c3f-9641-8f62bd36af04</v>
+                <v>Destruct</v>
+                <v>ed4db4bc-d115-449b-b919-9ea109477a00</v>
+              </d>
+              <v n="FbName">"NotImportant"</v>
+              <v n="FbGuid">{46038cbc-714f-4f35-b697-7f366f8e7109}</v>
+            </o>
+            <v n="GeneratedGlobalVisuVarsGuid">{46bbb596-ae47-493f-a5f2-8de4f4afc195}</v>
+            <v n="GeneratedGlobalTheVisuVarlistGuid">{1cdb18f1-4769-4cdb-9447-fdfef74a947b}</v>
+            <v n="GeneratedGlobalVisuConstants">{0fbf1c33-9428-4f1e-a0c4-a80bca6987e0}</v>
+            <d n="GeneratedAllElementsEntries" t="Hashtable" />
+            <o n="VisuRegDesc" t="GenericFbDescription">
+              <d n="FbMethods" t="CaseInsensitiveHashtable_1" ckt="String" cvt="Guid">
+                <v>FB_Init</v>
+                <v>5246bfdf-08f9-4cf9-8bc5-522acb1faf96</v>
+                <v>FB_Exit</v>
+                <v>3579d26b-95cf-416d-b76b-fe06e536a11b</v>
+                <v>FB_Reinit</v>
+                <v>0f87156c-fede-4032-9cf1-9775297d06af</v>
+              </d>
+              <v n="FbName">"NotImportant"</v>
+              <v n="FbGuid">{1e7de096-d2a1-46a1-afb9-be3a38b3d95a}</v>
+            </o>
+            <v n="VisuRegisterGvl">{9a2ab23a-2db1-41d2-98a8-eea67735ceb0}</v>
+            <n n="SettingsPou" />
+            <n n="MemManPou" />
+            <o n="InputsPou" t="GenericFbDescription">
+              <d n="FbMethods" t="CaseInsensitiveHashtable_1" ckt="String" cvt="Guid">
+                <v>ExecuteLooseCapture</v>
+                <v>4dc33a95-063f-4c92-adc3-2b61d9c0217d</v>
+                <v>ExecuteMouseDblClick</v>
+                <v>ac929500-7079-402f-acb5-a53ca48a88bd</v>
+                <v>ExecuteMouseDown</v>
+                <v>4e811b80-03c1-4bd4-ae88-c5f0c18b2218</v>
+                <v>ExecuteMouseUp</v>
+                <v>5b495f19-514b-4c0f-9419-9f1c3905807a</v>
+                <v>GetElementInfo</v>
+                <v>b044d94f-9781-4510-aa36-d2ec9b894b96</v>
+                <v>abstrGetDefaultCursor</v>
+                <v>184febce-8517-4408-bb44-4e82dfd86869</v>
+                <v>ExecuteDialogClosed</v>
+                <v>c3f447c0-0a56-4816-b21a-a7720c3411a2</v>
+                <v>ExecuteKeyUp</v>
+                <v>59faff27-c591-4776-9e5c-a92f03ecfee8</v>
+                <v>ExecuteKeyDown</v>
+                <v>dc6dbfc0-acdc-476b-95f2-3b4c41bdb8e0</v>
+                <v>ExecuteMouseMove</v>
+                <v>6bf4300c-61c7-45a7-be5e-28a9387330fc</v>
+                <v>Initialize</v>
+                <v>5f53bf23-378a-46bd-a55b-0c16fe3909f9</v>
+                <v>ExecuteMouseEnter</v>
+                <v>a7287267-1e8f-4ae8-b039-360e988e8cef</v>
+                <v>ExecuteMouseLeave</v>
+                <v>9d74b47e-98ca-444e-b5c4-a8c0094a42c7</v>
+                <v>ExecuteMouseClick</v>
+                <v>ce8c4777-5d52-43e2-b60d-78191cab5ce3</v>
+              </d>
+              <v n="FbName">"NotImportant"</v>
+              <v n="FbGuid">{5e3bd2b7-969c-4dda-a67c-aac8e53b5f8a}</v>
+            </o>
+            <v n="DialogDut">{84e0da50-b9c2-4622-9f09-25dd660eeaa0}</v>
+          </o>
+          <v n="LastUsedIdForIdentifier">11</v>
+          <o n="TextDocument" t="TextDocument">
+            <a n="TextLines" cet="TextLine">
+              <o>
+                <v n="Id">2L</v>
+                <n n="Tag" />
+                <v n="Text">"VAR_IN_OUT"</v>
+              </o>
+              <o>
+                <v n="Id">3L</v>
+                <n n="Tag" />
+                <v n="Text">"	"</v>
+              </o>
+              <o>
+                <v n="Id">1L</v>
+                <n n="Tag" />
+                <v n="Text">"END_VAR"</v>
+              </o>
+            </a>
+          </o>
+          <v n="GvlCreated">false</v>
+          <n n="LMEntry" />
+          <v n="ProfileCompatibilityId">4140216668L</v>
+          <v n="LMVerMinor">0</v>
+          <v n="LMVerMajor">1</v>
+          <o n="Hotkeys" t="HotkeyConfiguration">
+            <v n="IdMin">481037385728L</v>
+            <v n="IdMax">549755813887L</v>
+            <v n="Id">481037385728L</v>
+            <v n="IdMask">549754765312L</v>
+            <v n="IdStep">1048576L</v>
+            <l2 n="Inputs" />
+          </o>
+          <o n="VisuSizeManager" t="VisualObjectSizeManager">
+            <d2 n="Size" ckt="Int32" cvt="VisualObjectSize">
+              <v>0</v>
+              <o>
+                <v n="Width">1567</v>
+                <v n="Height">357</v>
+              </o>
+              <v>1</v>
+              <o>
+                <v n="Width">1567</v>
+                <v n="Height">357</v>
+              </o>
+            </d2>
+            <v n="Version">1</v>
+          </o>
+        </o>
+      </Data>
+      <TypeList>
+        <Type n="ArrayList">System.Collections.ArrayList</Type>
+        <Type n="BackgroundSettings">{1038f12c-dd4b-4f96-87a3-a350fe8f3552}</Type>
+        <Type n="BasicTypeNode">{f7e1e748-ea0f-4fcb-b563-94837ee17e8d}</Type>
+        <Type n="Boolean">System.Boolean</Type>
+        <Type n="CaseInsensitiveHashtable">{02a85e84-ef2d-46fc-93f2-acb0bbff3eda}</Type>
+        <Type n="CaseInsensitiveHashtable_1">{7df88604-7ac5-4e36-91c4-55e4fdad3e68}</Type>
+        <Type n="ComplexInput">{1de566f6-72a7-494c-9353-9a418172c96e}</Type>
+        <Type n="Double">System.Double</Type>
+        <Type n="DynamicArrayNode">{6c16f79c-dd98-4c29-b3ba-7042e3055542}</Type>
+        <Type n="GeneratedLanguageModelEntriesData">{703465dc-4679-4ff2-bcc3-c57d0a204da3}</Type>
+        <Type n="GenericFbDescription">{40d6dd8d-dfd0-493a-8e29-c9a35e1e6539}</Type>
+        <Type n="GenericVisualElem">{f86c2928-8614-4cca-824b-e819ac4d58c4}</Type>
+        <Type n="Guid">System.Guid</Type>
+        <Type n="Hashtable">System.Collections.Hashtable</Type>
+        <Type n="HotkeyConfiguration">{6b108d46-58af-4e41-a3f4-174d8f160cc4}</Type>
+        <Type n="Int16">System.Int16</Type>
+        <Type n="Int32">System.Int32</Type>
+        <Type n="Int64">System.Int64</Type>
+        <Type n="NamedStyleColor">{fa491db2-51ff-4bc1-9cd0-ce8c94ff6216}</Type>
+        <Type n="NamedStyleFont">{9e842eb2-1463-4af2-b605-4fbb17044f94}</Type>
+        <Type n="String">System.String</Type>
+        <Type n="StructuredTypeNode">{503c5b2e-e80e-4ee7-ae00-c5b93a62b1aa}</Type>
+        <Type n="TextDocument">{f3878285-8e4f-490b-bb1b-9acbb7eb04db}</Type>
+        <Type n="TextLine">{a5de0b0b-1cb5-4913-ac21-9d70293ec00d}</Type>
+        <Type n="TypeClass">{16f7aa24-038f-444e-9d81-b001bc091d35}</Type>
+        <Type n="TypeNodeAttributes2">{c1464dbe-c10d-4717-be8f-63efe8638434}</Type>
+        <Type n="TypeNodeType">{b12a9636-e818-4598-ae0d-fb6a2446102c}</Type>
+        <Type n="UInt16">System.UInt16</Type>
+        <Type n="UInt32">System.UInt32</Type>
+        <Type n="UInt64">System.UInt64</Type>
+        <Type n="VisualElemCollection">{ef9d0b20-c96e-48db-b361-2ded4063150e}</Type>
+        <Type n="VisualElemList">{f285c9a3-7019-446b-b98c-ccec3a0af8fa}</Type>
+        <Type n="VisualElemMember">{c694e3a2-5c0b-4177-ab35-cb06bd5a6a02}</Type>
+        <Type n="VisualElemMemberCollection">{a4b83bea-3742-489c-9fe8-d96d68dba7ab}</Type>
+        <Type n="VisualElemMemberList">{17e26cd1-bb9b-47fe-a3d5-18fcd63b9c96}</Type>
+        <Type n="VisualFrameInfo">{7fd6515d-f891-4717-b53f-b14197c6706c}</Type>
+        <Type n="VisualizationNode">{f8db32ff-bdd5-49e9-9014-6d9a6dea5d8c}</Type>
+        <Type n="VisualObject">{f18bec89-9fef-401d-9953-2f11739a6808}</Type>
+        <Type n="VisualObjectSize">{6ad3e88f-aee2-4766-a7ea-a8790037ef51}</Type>
+        <Type n="VisualObjectSizeManager">{5f612b0e-b404-455f-8177-27864e9f5332}</Type>
+      </TypeList>
+    </XmlArchive>
+  </Visu>
+</TcPlcObject>

--- a/lcls-twincat-motion-example/tc_mot_example/Visualization Manager.TcVMO
+++ b/lcls-twincat-motion-example/tc_mot_example/Visualization Manager.TcVMO
@@ -1,0 +1,576 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
+  <VisuManager Name="Visualization Manager" Id="{841b511d-6ece-4cea-ab48-9457957a298e}">
+    <XmlArchive>
+      <Data>
+        <o xml:space="preserve" t="VisualManagerObject">
+          <v n="UseUnicodeStrings" t="UnicodeSupport">Undefined</v>
+          <o n="ViewSettings" t="VisualManagerViewSettings">
+            <n n="StartVisu" />
+            <v n="StartVisu33">"AT1K4"</v>
+            <v n="OpenTargetvisu">false</v>
+            <v n="BestFit">false</v>
+            <v n="ClientSizeMode" t="VisualClientSizeMode">AutoDetect</v>
+            <v n="ClientSizeX">2000</v>
+            <v n="ClientSizeY">2000</v>
+            <v n="ExtendedSettings">false</v>
+            <v n="PaintBufferSize">50000</v>
+            <v n="MemorybufferSize">400000</v>
+            <v n="VisuInternal">false</v>
+            <v n="CurrentVisuGlobal">false</v>
+            <v n="FileTransferMode">true</v>
+            <v n="VisuStyle">"Flat style, 3.1.7.0 (Beckhoff Automation GmbH)"</v>
+            <v n="MaxNumOfClients">100</v>
+            <n n="Language" />
+            <v n="NumpadDialog">"VisuDialogs.Numpad"</v>
+            <v n="KeypadDialog">"VisuDialogs.Keypad"</v>
+            <v n="InputWithLimitsDialog">"VisuDialogs.TextinputWithLimits"</v>
+            <v n="UseInputWithLimits">false</v>
+            <v n="TouchHandlingActive">false</v>
+            <v n="SemiTransparentDrawingActive">true</v>
+            <v n="UpdateColorvariablesAfterActivationDone">true</v>
+            <v n="TransferSvgAndConvertedImages">false</v>
+            <v n="LoginDialog">"VisuUserManagement.VUM_Login"</v>
+            <v n="ChangePasswordDialog">"VisuUserManagement.VUM_ChangePassword"</v>
+            <v n="ChangeConfigDialog">"VisuUserManagement.VUM_UserManagement"</v>
+            <v n="GuidShowChangePasswordDialogFunction">{00000000-0000-0000-0000-000000000000}</v>
+            <v n="GuidShowChangeConfigDialogFunction">{00000000-0000-0000-0000-000000000000}</v>
+            <v n="UseStandardKeyboardHandling">true</v>
+            <v n="PaintDeactiveElementsGrayedOut">true</v>
+            <o n="GlobalOpenNumpadKeypadSettings" t="VisualManagerGlobalOpenNumpadKeypadSettings">
+              <v n="GlobalOpenNumpadKeypadType" t="GlobalOpenNumpadKeypadType">OpenCentered</v>
+              <n n="PositionX" />
+              <n n="PositionY" />
+            </o>
+            <v n="ConvertImages">false</v>
+            <v n="ConversionType">""</v>
+          </o>
+          <o n="RegisterDesc" t="GenericFbDescription">
+            <d n="FbMethods" t="CaseInsensitiveHashtable" ckt="String" cvt="Guid">
+              <v>FB_Init</v>
+              <v>8b83f44d-054a-4440-b4d1-d35814e9a13b</v>
+              <v>FB_Exit</v>
+              <v>a2191a9c-150e-4d81-b023-7cfe182c973b</v>
+              <v>FB_Reinit</v>
+              <v>458f4fe2-924c-4e23-9b88-6ea5c25659e8</v>
+            </d>
+            <v n="FbName">"NotImportant"</v>
+            <v n="FbGuid">{9f58808c-06fa-4425-bb6e-703852ef3d09}</v>
+          </o>
+          <o n="TargetProperties" t="VisualizationTargetProperties">
+            <o n="AvailableKeys" t="DeviceBasedHotkeysProvider">
+              <v n="Modifiers">7</v>
+              <v n="DevType">4096</v>
+              <v n="DevId">"1002 0004"</v>
+              <v n="DevVersion">"1.0.0.5"</v>
+              <v n="BaseProvider">{cb73a13e-6ccc-4bc6-8859-f5aa98bb116b}</v>
+              <l n="Keys" t="ArrayList" cet="DeviceBasedHotkeyItem">
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">48</v>
+                  <v n="CanonicalName">"0"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">49</v>
+                  <v n="CanonicalName">"1"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">50</v>
+                  <v n="CanonicalName">"2"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">51</v>
+                  <v n="CanonicalName">"3"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">52</v>
+                  <v n="CanonicalName">"4"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">53</v>
+                  <v n="CanonicalName">"5"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">54</v>
+                  <v n="CanonicalName">"6"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">55</v>
+                  <v n="CanonicalName">"7"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">56</v>
+                  <v n="CanonicalName">"8"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">57</v>
+                  <v n="CanonicalName">"9"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">65</v>
+                  <v n="CanonicalName">"A"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">107</v>
+                  <v n="CanonicalName">"ADDITION"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">66</v>
+                  <v n="CanonicalName">"B"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">8</v>
+                  <v n="CanonicalName">"BACKSPACE"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">67</v>
+                  <v n="CanonicalName">"C"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">110</v>
+                  <v n="CanonicalName">"COMMA"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">68</v>
+                  <v n="CanonicalName">"D"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">46</v>
+                  <v n="CanonicalName">"DELETE"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">111</v>
+                  <v n="CanonicalName">"DIVIDE"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">40</v>
+                  <v n="CanonicalName">"DOWN"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">69</v>
+                  <v n="CanonicalName">"E"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">35</v>
+                  <v n="CanonicalName">"END"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">27</v>
+                  <v n="CanonicalName">"ESCAPE"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">70</v>
+                  <v n="CanonicalName">"F"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">112</v>
+                  <v n="CanonicalName">"F1"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">121</v>
+                  <v n="CanonicalName">"F10"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">122</v>
+                  <v n="CanonicalName">"F11"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">123</v>
+                  <v n="CanonicalName">"F12"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">113</v>
+                  <v n="CanonicalName">"F2"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">114</v>
+                  <v n="CanonicalName">"F3"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">115</v>
+                  <v n="CanonicalName">"F4"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">116</v>
+                  <v n="CanonicalName">"F5"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">117</v>
+                  <v n="CanonicalName">"F6"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">118</v>
+                  <v n="CanonicalName">"F7"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">119</v>
+                  <v n="CanonicalName">"F8"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">120</v>
+                  <v n="CanonicalName">"F9"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">71</v>
+                  <v n="CanonicalName">"G"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">72</v>
+                  <v n="CanonicalName">"H"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">36</v>
+                  <v n="CanonicalName">"HOME"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">73</v>
+                  <v n="CanonicalName">"I"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">45</v>
+                  <v n="CanonicalName">"INSERT"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">74</v>
+                  <v n="CanonicalName">"J"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">75</v>
+                  <v n="CanonicalName">"K"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">76</v>
+                  <v n="CanonicalName">"L"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">37</v>
+                  <v n="CanonicalName">"LEFT"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">77</v>
+                  <v n="CanonicalName">"M"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">106</v>
+                  <v n="CanonicalName">"MULTIPLY"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">78</v>
+                  <v n="CanonicalName">"N"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">96</v>
+                  <v n="CanonicalName">"NUM0"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">97</v>
+                  <v n="CanonicalName">"NUM1"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">98</v>
+                  <v n="CanonicalName">"NUM2"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">99</v>
+                  <v n="CanonicalName">"NUM3"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">100</v>
+                  <v n="CanonicalName">"NUM4"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">101</v>
+                  <v n="CanonicalName">"NUM5"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">102</v>
+                  <v n="CanonicalName">"NUM6"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">103</v>
+                  <v n="CanonicalName">"NUM7"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">104</v>
+                  <v n="CanonicalName">"NUM8"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">105</v>
+                  <v n="CanonicalName">"NUM9"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">79</v>
+                  <v n="CanonicalName">"O"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">80</v>
+                  <v n="CanonicalName">"P"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">19</v>
+                  <v n="CanonicalName">"PAUSE"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">42</v>
+                  <v n="CanonicalName">"PRINT"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">81</v>
+                  <v n="CanonicalName">"Q"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">82</v>
+                  <v n="CanonicalName">"R"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">13</v>
+                  <v n="CanonicalName">"RETURN_KEY"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">39</v>
+                  <v n="CanonicalName">"RIGHT"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">83</v>
+                  <v n="CanonicalName">"S"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">32</v>
+                  <v n="CanonicalName">"SPACE"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">109</v>
+                  <v n="CanonicalName">"SUBTRACT"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">84</v>
+                  <v n="CanonicalName">"T"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">9</v>
+                  <v n="CanonicalName">"TAB"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">85</v>
+                  <v n="CanonicalName">"U"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">38</v>
+                  <v n="CanonicalName">"UP"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">86</v>
+                  <v n="CanonicalName">"V"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">87</v>
+                  <v n="CanonicalName">"W"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">88</v>
+                  <v n="CanonicalName">"X"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">89</v>
+                  <v n="CanonicalName">"Y"</v>
+                </o>
+                <o>
+                  <v n="FromBase">true</v>
+                  <v n="KeyCode">90</v>
+                  <v n="CanonicalName">"Z"</v>
+                </o>
+              </l>
+            </o>
+          </o>
+          <o n="ConfiguredHotkeys" t="HotkeyConfiguration">
+            <v n="IdMin">481037385728L</v>
+            <v n="IdMax">549755813887L</v>
+            <v n="Id">481037385728L</v>
+            <v n="IdMask">549754765312L</v>
+            <v n="IdStep">1048576L</v>
+            <l2 n="Inputs" />
+          </o>
+          <o n="DefInpHandlerGuids" t="GenericFbDescription">
+            <d n="FbMethods" t="CaseInsensitiveHashtable" ckt="String" cvt="Guid">
+              <v>ExecuteLooseCapture</v>
+              <v>79e2c68d-4264-4c16-a021-84bd43715cd7</v>
+              <v>ExecuteMouseUp</v>
+              <v>41c5467d-dcc0-4564-9e2b-e92a075d7395</v>
+              <v>Init</v>
+              <v>26b0b81d-3132-4b1c-93b5-6e9ce783e5b5</v>
+              <v>FB_Exit</v>
+              <v>865e658b-c280-4721-a3ec-05ada74d7836</v>
+              <v>ExecuteMouseDblClick</v>
+              <v>988b4781-cf53-4c83-8ad2-cc07bbcebc2d</v>
+              <v>GetElementInfo</v>
+              <v>409b8368-2fc2-40f2-a8ba-2d6e8b8fa3bd</v>
+              <v>ExecuteMouseDown</v>
+              <v>7800b7e6-87c3-429f-8609-15a698f98d87</v>
+              <v>FB_Reinit</v>
+              <v>43804c4b-164b-4262-a4c6-31b65cfc7cb9</v>
+              <v>Initialize</v>
+              <v>9299998d-1644-4999-9afb-c4c3ad5acdbf</v>
+              <v>ExecuteMouseMove</v>
+              <v>92cd664b-3133-4046-9b48-37df6297fdae</v>
+              <v>ExecuteDialogClosed</v>
+              <v>94732a68-a0d0-44a7-9a22-8573f5e7f12d</v>
+              <v>ExecuteKeyUp</v>
+              <v>e38ae9a3-202f-4818-add4-b3131c8817e5</v>
+              <v>ExecuteKeyDown</v>
+              <v>8777f733-04e8-42dc-980e-b3edf1dcd4fd</v>
+              <v>abstrGetDefaultCursor</v>
+              <v>ee4c9685-3729-43ad-84f7-423381c7a724</v>
+              <v>ExecuteMouseEnter</v>
+              <v>8e6f830c-c926-43c2-a173-d16957697e5b</v>
+              <v>ExecuteMouseLeave</v>
+              <v>6f17fc6e-a25d-4619-a6de-6c3816d61146</v>
+              <v>FB_Init</v>
+              <v>bd534992-ef46-439e-8d5d-f0c6126fa066</v>
+              <v>ExecuteMouseClick</v>
+              <v>5ccb2cd4-19f2-4b47-9ac9-84b1c23f232a</v>
+            </d>
+            <v n="FbName">"NotImportant"</v>
+            <v n="FbGuid">{79a74d14-c398-4c0b-894f-4536cbc5784b}</v>
+          </o>
+          <n n="InstantiationStorage" />
+          <n n="VisuUserManagement" />
+          <v n="UseLocalUserMgmt">true</v>
+          <v n="UseUserMgmtInPlc">true</v>
+          <n n="RemoteUserMgmtPath" />
+          <n n="FontsConfig" />
+          <n n="FontDownloadConfig" />
+          <n n="VisuInitializationCode" />
+          <n n="FontSettings" />
+          <v n="GuidVisuSettingsPou">{96e0463b-e0d1-4c14-9c46-bc9760ba2dc5}</v>
+          <v n="GuidVisuSettingsPouInit">{4bba6beb-ad5b-46dd-a262-7c2f4ebb7d9e}</v>
+          <v n="GuidVisuSettingsPouReInit">{27e628b9-fd66-4458-9cbc-b4b9028fc401}</v>
+          <v n="GuidVisuSettingsPouBoolMethod">{22348970-cf6c-4b78-92c2-eb2972faf4db}</v>
+          <v n="GuidVisuSettingsPouDIntMethod">{b1a26f30-79c8-4898-a39d-e3e5260e3bc1}</v>
+          <v n="GuidVisuSettingsPouStringMethod">{4506e52d-30e1-4a67-b5a0-bfb318aa983f}</v>
+          <v n="GuidVisuSettingsPouReservedMethod">{84051c55-9f47-4e39-a49e-bc1eaf6793ee}</v>
+          <v n="GuidMemManInitPou">{f0f70d10-0ab3-4d65-89ee-6a579478eebe}</v>
+          <v n="GuidMemManInitPouInit">{613238c5-be58-4980-9bc0-981c728ebbdc}</v>
+          <v n="GuidMemManInitPouReInit">{b09963e2-0dd0-42b7-aaf9-92a0a439fe13}</v>
+          <v n="GuidStartVisuInitPou">{a1c6f718-c94e-41d2-8dcf-13ebe19a6697}</v>
+          <v n="GuidStartVisuInitPouInit">{db38e435-9650-4a36-a504-fe987bf156a6}</v>
+          <v n="GuidStartVisuInitPouReInit">{5125bdb5-3e3e-47ce-8082-6c6cbdbe7555}</v>
+          <v n="GuidVisuGVL0">{fda0a726-22ad-4f26-99d3-bfb098869a64}</v>
+          <v n="GuidVisuGVL1">{9ab0e135-9de5-4e3d-9e42-e23dccf414aa}</v>
+          <v n="GuidVisuGVL2">{3b8fae50-aca1-412a-bc88-c75b9196bf7c}</v>
+          <v n="GuidVisuGVL_3">{aeea8c0c-dc40-4f9a-8739-9de1f6e03749}</v>
+          <v n="GuidReservedPou">{3d95f8d9-f29b-4db4-8d08-6f0fb0e12959}</v>
+          <v n="GuidVisuGVL3">{4d43137d-7e75-4288-a0a4-d54343b85d20}</v>
+          <v n="GuidReservedPouInit">{f8de9d5d-0718-4051-bf14-bcb18e8ed66c}</v>
+          <v n="GuidVisuGVL4">{dd776e7a-2838-450c-ae8d-898c513cfa42}</v>
+          <v n="GuidVisuGVL5">{f38c4329-1b1d-4b8e-a1f9-4f95eda54ecf}</v>
+          <v n="GuidLicenseGVL">{29f19af6-f994-4d14-9072-703733efdff8}</v>
+          <v n="GuidGlobalClientManagerGVL">{d52ec30a-ac94-4934-a6b8-a303fd3d1fe2}</v>
+          <v n="GuidVisuUserMgmtInitPou">{c56ebe01-f39b-49b7-b57b-de9f80272ca3}</v>
+          <v n="GuidVisuUserMgmtInitPouInit">{4d79e063-b644-40ee-aedb-19087d65d714}</v>
+          <v n="GuidBeforeCompileCommonGVL">{7ecdae81-c589-4657-8ceb-ad41398ddd8d}</v>
+          <v n="GuidVisuGVL6">{3a79019b-0028-4fd8-a4a7-53c74f40b58f}</v>
+          <v n="GuidReservedPouMethod1">{768e93fe-83fe-42c7-b8bf-c654d353aac9}</v>
+          <v n="GuidReservedPouReInit">{c8528aeb-6f34-405d-864a-5367f507fdda}</v>
+          <v n="GuidReservedPouMethod0">{57071bdf-baf4-4c3a-a27f-2870210ca386}</v>
+          <v n="GuidReservedPouMethod2">{90072efa-68a7-45e7-b4d3-a7e52255b9bb}</v>
+        </o>
+      </Data>
+      <TypeList>
+        <Type n="ArrayList">System.Collections.ArrayList</Type>
+        <Type n="Boolean">System.Boolean</Type>
+        <Type n="CaseInsensitiveHashtable">{7df88604-7ac5-4e36-91c4-55e4fdad3e68}</Type>
+        <Type n="DeviceBasedHotkeyItem">{11a86981-4b02-4f98-b432-96e385cb41b7}</Type>
+        <Type n="DeviceBasedHotkeysProvider">{c91fc5aa-1e38-43b2-9a05-c52cc5d7f5b6}</Type>
+        <Type n="GenericFbDescription">{40d6dd8d-dfd0-493a-8e29-c9a35e1e6539}</Type>
+        <Type n="GlobalOpenNumpadKeypadType">{550f8ee0-c42e-42f0-b253-4fadf0c12bdf}</Type>
+        <Type n="Guid">System.Guid</Type>
+        <Type n="HotkeyConfiguration">{6b108d46-58af-4e41-a3f4-174d8f160cc4}</Type>
+        <Type n="Int32">System.Int32</Type>
+        <Type n="Int64">System.Int64</Type>
+        <Type n="String">System.String</Type>
+        <Type n="UnicodeSupport">{19611221-ebd3-4607-86d2-9822fbe84c30}</Type>
+        <Type n="VisualClientSizeMode">{c37fe731-4f69-4d98-82fe-4f9aefbe200d}</Type>
+        <Type n="VisualizationTargetProperties">{997fedbb-1888-4256-b61c-2933d8056bfd}</Type>
+        <Type n="VisualManagerGlobalOpenNumpadKeypadSettings">{422ed780-41e9-4352-8132-b322b16154c1}</Type>
+        <Type n="VisualManagerObject">{4d3fdb8f-ab50-4c35-9d3a-d4bb9bb9a628}</Type>
+        <Type n="VisualManagerViewSettings">{ec9b2ec6-92a2-4856-be72-7866fb274c64}</Type>
+      </TypeList>
+    </XmlArchive>
+  </VisuManager>
+</TcPlcObject>

--- a/lcls-twincat-motion-example/tc_mot_example/tc_mot_example.plcproj
+++ b/lcls-twincat-motion-example/tc_mot_example/tc_mot_example.plcproj
@@ -15,11 +15,21 @@
     <LibraryReferences>{b7bab649-b18f-4421-a81c-7a3381e3f2d7}</LibraryReferences>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GlobalTextList.TcGTLO">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="PlcTask.TcTTO">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Main.TcPOU">
       <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Visualization Manager.TcVMO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="VISUs\Visualization.TcVIS">
+      <SubType>Code</SubType>
+      <DependentUpon>Visualization Manager.TcVMO</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -33,6 +43,48 @@
       <DefaultResolution>lcls-twincat-motion, * (SLAC)</DefaultResolution>
       <Namespace>lcls_twincat_motion</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="System_VisuElemMeter">
+      <DefaultResolution>VisuElemMeter, 3.5.13.0 (System)</DefaultResolution>
+      <Namespace>VisuElemMeter</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
+    <PlaceholderReference Include="System_VisuElems">
+      <DefaultResolution>VisuElems, 3.5.13.40 (System)</DefaultResolution>
+      <Namespace>VisuElems</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
+    <PlaceholderReference Include="System_VisuElemsSpecialControls">
+      <DefaultResolution>VisuElemsSpecialControls, 3.5.13.0 (System)</DefaultResolution>
+      <Namespace>VisuElemsSpecialControls</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
+    <PlaceholderReference Include="System_VisuElemsWinControls">
+      <DefaultResolution>VisuElemsWinControls, 3.5.13.20 (System)</DefaultResolution>
+      <Namespace>VisuElemsWinControls</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
+    <PlaceholderReference Include="System_VisuElemTextEditor">
+      <DefaultResolution>VisuElemTextEditor, 3.5.13.0 (System)</DefaultResolution>
+      <Namespace>VisuElemTextEditor</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
+    <PlaceholderReference Include="system_visuinputs">
+      <DefaultResolution>visuinputs, 3.5.13.0 (system)</DefaultResolution>
+      <Namespace>visuinputs</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
+    <PlaceholderReference Include="System_VisuNativeControl">
+      <DefaultResolution>VisuNativeControl, 3.5.13.0 (System)</DefaultResolution>
+      <Namespace>VisuNativeControl</Namespace>
+      <SystemLibrary>true</SystemLibrary>
+      <ResolverGuid>2717eb6a-dd07-4c66-8d8d-cacebd7b18ae</ResolverGuid>
+    </PlaceholderReference>
     <PlaceholderReference Include="Tc2_Standard">
       <DefaultResolution>Tc2_Standard, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_Standard</Namespace>
@@ -45,10 +97,36 @@
       <DefaultResolution>Tc3_Module, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc3_Module</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="VisuDialogs">
+      <DefaultResolution>VisuDialogs, * (System)</DefaultResolution>
+      <Namespace>VisuDialogs</Namespace>
+    </PlaceholderReference>
+    <PlaceholderReference Include="VisuSymbols">
+      <DefaultResolution>VisuSymbols, * (System)</DefaultResolution>
+      <Namespace>VisuSymbols</Namespace>
+    </PlaceholderReference>
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 1.1.0 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, * (SLAC)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="System_VisuElemBase">
+      <Resolution>VisuElemBase, * (System)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="System_VisuElemMeter">
+      <Resolution>VisuElemMeter, * (System)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="System_VisuElems">
+      <Resolution>VisuElems, * (System)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="System_VisuElemsSpecialControls">
+      <Resolution>VisuElemsSpecialControls, * (System)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="System_VisuElemsWinControls">
+      <Resolution>VisuElemsWinControls, * (System)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="System_VisuElemTextEditor">
+      <Resolution>VisuElemTextEditor, * (System)</Resolution>
     </PlaceholderResolution>
   </ItemGroup>
   <ItemGroup>
@@ -59,35 +137,67 @@
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>
-        <Data>
-          <o xml:space="preserve" t="OptionKey">
+  <Data>
+    <o xml:space="preserve" t="OptionKey">
       <v n="Name">"&lt;ProjectRoot&gt;"</v>
       <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
-        <v>{40450F57-0AA3-4216-96F3-5444ECB29763}</v>
-        <o>
-          <v n="Name">"{40450F57-0AA3-4216-96F3-5444ECB29763}"</v>
-          <d n="SubKeys" t="Hashtable" />
-          <d n="Values" t="Hashtable" ckt="String" cvt="String">
-            <v>ActiveVisuProfile</v>
-            <v>IR0whWr8bwfyBwAAHf+pawAAAABVAgAADnffSgAAAAABAAAAAAAAAAEaUwB5AHMAdABlAG0ALgBTAHQAcgBpAG4AZwACTHsAZgA5ADUAYgBiADQAMgA2AC0ANQA1ADIANAAtADQAYgA0ADUALQA5ADQAMAAwAC0AZgBiADAAZgAyAGUANwA3AGUANQAxAGIAfQADCE4AYQBtAGUABDJUAHcAaQBuAEMAQQBUACAAMwAuADEAIABCAHUAaQBsAGQAIAA0ADAAMgAyAC4AMQAwAAUWUAByAG8AZgBpAGwAZQBEAGEAdABhAAZMewAxADYAZQA1ADUAYgA2ADAALQA3ADAANAAzAC0ANABhADYAMwAtAGIANgA1AGIALQA2ADEANAA3ADEAMwA4ADcAOABkADQAMgB9AAcSTABpAGIAcgBhAHIAaQBlAHMACEx7ADMAYgBmAGQANQA0ADUAOQAtAGIAMAA3AGYALQA0AGQANgBlAC0AYQBlADEAYQAtAGEAOAAzADMANQA2AGEANQA1ADEANAAyAH0ACUx7ADkAYwA5ADUAOAA5ADYAOAAtADIAYwA4ADUALQA0ADEAYgBiAC0AOAA4ADcAMQAtADgAOQA1AGYAZgAxAGYAZQBkAGUAMQBhAH0ACg5WAGUAcgBzAGkAbwBuAAsGaQBuAHQADApVAHMAYQBnAGUADQpUAGkAdABsAGUADhpWAGkAcwB1AEUAbABlAG0ATQBlAHQAZQByAA8OQwBvAG0AcABhAG4AeQAQDFMAeQBzAHQAZQBtABESVgBpAHMAdQBFAGwAZQBtAHMAEjBWAGkAcwB1AEUAbABlAG0AcwBTAHAAZQBjAGkAYQBsAEMAbwBuAHQAcgBvAGwAcwATKFYAaQBzAHUARQBsAGUAbQBzAFcAaQBuAEMAbwBuAHQAcgBvAGwAcwAUJFYAaQBzAHUARQBsAGUAbQBUAGUAeAB0AEUAZABpAHQAbwByABUiVgBpAHMAdQBOAGEAdABpAHYAZQBDAG8AbgB0AHIAbwBsABYUdgBpAHMAdQBpAG4AcAB1AHQAcwAXDHMAeQBzAHQAZQBtABgYVgBpAHMAdQBFAGwAZQBtAEIAYQBzAGUAGSZEAGUAdgBQAGwAYQBjAGUAaABvAGwAZABlAHIAcwBVAHMAZQBkABoIYgBvAG8AbAAbIlAAbAB1AGcAaQBuAEMAbwBuAHMAdAByAGEAaQBuAHQAcwAcTHsANAAzAGQANQAyAGIAYwBlAC0AOQA0ADIAYwAtADQANABkADcALQA5AGUAOQA0AC0AMQBiAGYAZABmADMAMQAwAGUANgAzAGMAfQAdHEEAdABMAGUAYQBzAHQAVgBlAHIAcwBpAG8AbgAeFFAAbAB1AGcAaQBuAEcAdQBpAGQAHxZTAHkAcwB0AGUAbQAuAEcAdQBpAGQAIEhhAGYAYwBkADUANAA0ADYALQA0ADkAMQA0AC0ANABmAGUANwAtAGIAYgA3ADgALQA5AGIAZgBmAGUAYgA3ADAAZgBkADEANwAhFFUAcABkAGEAdABlAEkAbgBmAG8AIkx7AGIAMAAzADMANgA2AGEAOAAtAGIANQBjADAALQA0AGIAOQBhAC0AYQAwADAAZQAtAGUAYgA4ADYAMAAxADEAMQAwADQAYwAzAH0AIw5VAHAAZABhAHQAZQBzACRMewAxADgANgA4AGYAZgBjADkALQBlADQAZgBjAC0ANAA1ADMAMgAtAGEAYwAwADYALQAxAGUAMwA5AGIAYgA1ADUANwBiADYAOQB9ACVMewBhADUAYgBkADQAOABjADMALQAwAGQAMQA3AC0ANAAxAGIANQAtAGIAMQA2ADQALQA1AGYAYwA2AGEAZAAyAGIAOQA2AGIANwB9ACYWTwBiAGoAZQBjAHQAcwBUAHkAcABlACdUVQBwAGQAYQB0AGUATABhAG4AZwB1AGEAZwBlAE0AbwBkAGUAbABGAG8AcgBDAG8AbgB2AGUAcgB0AGkAYgBsAGUATABpAGIAcgBhAHIAaQBlAHMAKBBMAGkAYgBUAGkAdABsAGUAKRRMAGkAYgBDAG8AbQBwAGEAbgB5ACoeVQBwAGQAYQB0AGUAUAByAG8AdgBpAGQAZQByAHMAKzhTAHkAcwB0AGUAbQAuAEMAbwBsAGwAZQBjAHQAaQBvAG4AcwAuAEgAYQBzAGgAdABhAGIAbABlACwSdgBpAHMAdQBlAGwAZQBtAHMALUg2AGMAYgAxAGMAZABlADEALQBkADUAZABjAC0ANABhADMAYgAtADkAMAA1ADQALQAyADEAZgBhADcANQA2AGEAMwBmAGEANAAuKEkAbgB0AGUAcgBmAGEAYwBlAFYAZQByAHMAaQBvAG4ASQBuAGYAbwAvTHsAYwA2ADEAMQBlADQAMAAwAC0ANwBmAGIAOQAtADQAYwAzADUALQBiADkAYQBjAC0ANABlADMAMQA0AGIANQA5ADkANgA0ADMAfQAwGE0AYQBqAG8AcgBWAGUAcgBzAGkAbwBuADEYTQBpAG4AbwByAFYAZQByAHMAaQBvAG4AMgxMAGUAZwBhAGMAeQAzMEwAYQBuAGcAdQBhAGcAZQBNAG8AZABlAGwAVgBlAHIAcwBpAG8AbgBJAG4AZgBvADQwTABvAGEAZABMAGkAYgByAGEAcgBpAGUAcwBJAG4AdABvAFAAcgBvAGoAZQBjAHQANRpDAG8AbQBwAGEAdABpAGIAaQBsAGkAdAB5ANAAAhoD0AMBLQTQBQYaB9AHCBoBRQcJCNAACRoERQoLBAMAAAAFAAAACgAAAAAAAADQDAutAgAAANANAS0O0A8BLRDQAAkaBEUKCwQDAAAABQAAAAoAAAAoAAAA0AwLrQEAAADQDQEtEdAPAS0Q0AAJGgRFCgsEAwAAAAUAAAAKAAAAAAAAANAMC60CAAAA0A0BLRLQDwEtENAACRoERQoLBAMAAAAFAAAACgAAACgAAADQDAutAgAAANANAS0T0A8BLRDQAAkaBEUKCwQDAAAABQAAAAoAAAAKAAAA0AwLrQIAAADQDQEtFNAPAS0Q0AAJGgRFCgsEAwAAAAUAAAAKAAAAKAAAANAMC60CAAAA0A0BLRXQDwEtENAACRoERQoLBAMAAAAFAAAACgAAAAAAAADQDAutAgAAANANAS0W0A8BLRfQAAkaBEUKCwQDAAAABQAAAAoAAAAoAAAA0AwLrQQAAADQDQEtGNAPAS0Q0BkarQFFGxwB0AAcGgJFHQsEAwAAAAUAAAAKAAAAAAAAANAeHy0g0CEiGgJFIyQC0AAlGgVFCgsEAwAAAAMAAAAAAAAACgAAANAmC60AAAAA0AMBLSfQKAEtEdApAS0Q0AAlGgVFCgsEAwAAAAMAAAAAAAAACgAAANAmC60BAAAA0AMBLSfQKAEtEdApAS0QmiorAUUAAQLQAAEtLNAAAS0X0AAfLS3QLi8aA9AwC60BAAAA0DELrRMAAADQMhqtANAzLxoD0DALrQIAAADQMQutAwAAANAyGq0A0DQarQDQNRqtAA==</v>
-          </d>
-        </o>
         <v>{192FAD59-8248-4824-A8DE-9177C94C195A}</v>
         <o>
           <v n="Name">"{192FAD59-8248-4824-A8DE-9177C94C195A}"</v>
           <d n="SubKeys" t="Hashtable" />
           <d n="Values" t="Hashtable" />
         </o>
+        <v>{246001F4-279D-43AC-B241-948EB31120E1}</v>
+        <o>
+          <v n="Name">"{246001F4-279D-43AC-B241-948EB31120E1}"</v>
+          <d n="SubKeys" t="Hashtable" />
+          <d n="Values" t="Hashtable" ckt="String" cvt="Boolean">
+            <v>UnicodeStrings</v>
+            <v>False</v>
+          </d>
+        </o>
+        <v>{29BD8D0C-3586-4548-BB48-497B9A01693F}</v>
+        <o>
+          <v n="Name">"{29BD8D0C-3586-4548-BB48-497B9A01693F}"</v>
+          <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
+            <v>Rules</v>
+            <o>
+              <v n="Name">"Rules"</v>
+              <d n="SubKeys" t="Hashtable" />
+              <d n="Values" t="Hashtable" />
+            </o>
+          </d>
+          <d n="Values" t="Hashtable" />
+        </o>
+        <v>{8F99A816-E488-41E4-9FA3-846536012284}</v>
+        <o>
+          <v n="Name">"{8F99A816-E488-41E4-9FA3-846536012284}"</v>
+          <d n="SubKeys" t="Hashtable" />
+          <d n="Values" t="Hashtable" />
+        </o>
+        <v>{40450F57-0AA3-4216-96F3-5444ECB29763}</v>
+        <o>
+          <v n="Name">"{40450F57-0AA3-4216-96F3-5444ECB29763}"</v>
+          <d n="SubKeys" t="Hashtable" />
+          <d n="Values" t="Hashtable" ckt="String">
+            <v>ActiveVisuExtensionsLength</v>
+            <v>0</v>
+            <v>ActiveVisuProfile</v>
+            <v>"IR0whWr8bwfwBwAAiD2qpQAAAABVAgAA37x72QAAAAABAAAAAAAAAAEaUwB5AHMAdABlAG0ALgBTAHQAcgBpAG4AZwACTHsAZgA5ADUAYgBiADQAMgA2AC0ANQA1ADIANAAtADQAYgA0ADUALQA5ADQAMAAwAC0AZgBiADAAZgAyAGUANwA3AGUANQAxAGIAfQADCE4AYQBtAGUABDBUAHcAaQBuAEMAQQBUACAAMwAuADEAIABCAHUAaQBsAGQAIAA0ADAAMgA0AC4ANwAFFlAAcgBvAGYAaQBsAGUARABhAHQAYQAGTHsAMQA2AGUANQA1AGIANgAwAC0ANwAwADQAMwAtADQAYQA2ADMALQBiADYANQBiAC0ANgAxADQANwAxADMAOAA3ADgAZAA0ADIAfQAHEkwAaQBiAHIAYQByAGkAZQBzAAhMewAzAGIAZgBkADUANAA1ADkALQBiADAANwBmAC0ANABkADYAZQAtAGEAZQAxAGEALQBhADgAMwAzADUANgBhADUANQAxADQAMgB9AAlMewA5AGMAOQA1ADgAOQA2ADgALQAyAGMAOAA1AC0ANAAxAGIAYgAtADgAOAA3ADEALQA4ADkANQBmAGYAMQBmAGUAZABlADEAYQB9AAoOVgBlAHIAcwBpAG8AbgALBmkAbgB0AAwKVQBzAGEAZwBlAA0KVABpAHQAbABlAA4aVgBpAHMAdQBFAGwAZQBtAE0AZQB0AGUAcgAPDkMAbwBtAHAAYQBuAHkAEAxTAHkAcwB0AGUAbQARElYAaQBzAHUARQBsAGUAbQBzABIwVgBpAHMAdQBFAGwAZQBtAHMAUwBwAGUAYwBpAGEAbABDAG8AbgB0AHIAbwBsAHMAEyhWAGkAcwB1AEUAbABlAG0AcwBXAGkAbgBDAG8AbgB0AHIAbwBsAHMAFCRWAGkAcwB1AEUAbABlAG0AVABlAHgAdABFAGQAaQB0AG8AcgAVIlYAaQBzAHUATgBhAHQAaQB2AGUAQwBvAG4AdAByAG8AbAAWFHYAaQBzAHUAaQBuAHAAdQB0AHMAFwxzAHkAcwB0AGUAbQAYGFYAaQBzAHUARQBsAGUAbQBCAGEAcwBlABkmRABlAHYAUABsAGEAYwBlAGgAbwBsAGQAZQByAHMAVQBzAGUAZAAaCGIAbwBvAGwAGyJQAGwAdQBnAGkAbgBDAG8AbgBzAHQAcgBhAGkAbgB0AHMAHEx7ADQAMwBkADUAMgBiAGMAZQAtADkANAAyAGMALQA0ADQAZAA3AC0AOQBlADkANAAtADEAYgBmAGQAZgAzADEAMABlADYAMwBjAH0AHRxBAHQATABlAGEAcwB0AFYAZQByAHMAaQBvAG4AHhRQAGwAdQBnAGkAbgBHAHUAaQBkAB8WUwB5AHMAdABlAG0ALgBHAHUAaQBkACBIYQBmAGMAZAA1ADQANAA2AC0ANAA5ADEANAAtADQAZgBlADcALQBiAGIANwA4AC0AOQBiAGYAZgBlAGIANwAwAGYAZAAxADcAIRRVAHAAZABhAHQAZQBJAG4AZgBvACJMewBiADAAMwAzADYANgBhADgALQBiADUAYwAwAC0ANABiADkAYQAtAGEAMAAwAGUALQBlAGIAOAA2ADAAMQAxADEAMAA0AGMAMwB9ACMOVQBwAGQAYQB0AGUAcwAkTHsAMQA4ADYAOABmAGYAYwA5AC0AZQA0AGYAYwAtADQANQAzADIALQBhAGMAMAA2AC0AMQBlADMAOQBiAGIANQA1ADcAYgA2ADkAfQAlTHsAYQA1AGIAZAA0ADgAYwAzAC0AMABkADEANwAtADQAMQBiADUALQBiADEANgA0AC0ANQBmAGMANgBhAGQAMgBiADkANgBiADcAfQAmFk8AYgBqAGUAYwB0AHMAVAB5AHAAZQAnVFUAcABkAGEAdABlAEwAYQBuAGcAdQBhAGcAZQBNAG8AZABlAGwARgBvAHIAQwBvAG4AdgBlAHIAdABpAGIAbABlAEwAaQBiAHIAYQByAGkAZQBzACgQTABpAGIAVABpAHQAbABlACkUTABpAGIAQwBvAG0AcABhAG4AeQAqHlUAcABkAGEAdABlAFAAcgBvAHYAaQBkAGUAcgBzACs4UwB5AHMAdABlAG0ALgBDAG8AbABsAGUAYwB0AGkAbwBuAHMALgBIAGEAcwBoAHQAYQBiAGwAZQAsEnYAaQBzAHUAZQBsAGUAbQBzAC1INgBjAGIAMQBjAGQAZQAxAC0AZAA1AGQAYwAtADQAYQAzAGIALQA5ADAANQA0AC0AMgAxAGYAYQA3ADUANgBhADMAZgBhADQALihJAG4AdABlAHIAZgBhAGMAZQBWAGUAcgBzAGkAbwBuAEkAbgBmAG8AL0x7AGMANgAxADEAZQA0ADAAMAAtADcAZgBiADkALQA0AGMAMwA1AC0AYgA5AGEAYwAtADQAZQAzADEANABiADUAOQA5ADYANAAzAH0AMBhNAGEAagBvAHIAVgBlAHIAcwBpAG8AbgAxGE0AaQBuAG8AcgBWAGUAcgBzAGkAbwBuADIMTABlAGcAYQBjAHkAMzBMAGEAbgBnAHUAYQBnAGUATQBvAGQAZQBsAFYAZQByAHMAaQBvAG4ASQBuAGYAbwA0MEwAbwBhAGQATABpAGIAcgBhAHIAaQBlAHMASQBuAHQAbwBQAHIAbwBqAGUAYwB0ADUaQwBvAG0AcABhAHQAaQBiAGkAbABpAHQAeQDQAAIaA9ADAS0E0AUGGgfQBwgaAUUHCQjQAAkaBEUKCwQDAAAABQAAAA0AAAAAAAAA0AwLrQIAAADQDQEtDtAPAS0Q0AAJGgRFCgsEAwAAAAUAAAANAAAAKAAAANAMC60BAAAA0A0BLRHQDwEtENAACRoERQoLBAMAAAAFAAAADQAAAAAAAADQDAutAgAAANANAS0S0A8BLRDQAAkaBEUKCwQDAAAABQAAAA0AAAAUAAAA0AwLrQIAAADQDQEtE9APAS0Q0AAJGgRFCgsEAwAAAAUAAAANAAAAAAAAANAMC60CAAAA0A0BLRTQDwEtENAACRoERQoLBAMAAAAFAAAADQAAAAAAAADQDAutAgAAANANAS0V0A8BLRDQAAkaBEUKCwQDAAAABQAAAA0AAAAAAAAA0AwLrQIAAADQDQEtFtAPAS0X0AAJGgRFCgsEAwAAAAUAAAANAAAAKAAAANAMC60EAAAA0A0BLRjQDwEtENAZGq0BRRscAdAAHBoCRR0LBAMAAAAFAAAADQAAAAAAAADQHh8tINAhIhoCRSMkAtAAJRoFRQoLBAMAAAADAAAAAAAAAAoAAADQJgutAAAAANADAS0n0CgBLRHQKQEtENAAJRoFRQoLBAMAAAADAAAAAAAAAAoAAADQJgutAQAAANADAS0n0CgBLRHQKQEtEJoqKwFFAAEC0AABLSzQAAEtF9AAHy0t0C4vGgPQMAutAQAAANAxC60XAAAA0DIarQDQMy8aA9AwC60CAAAA0DELrQMAAADQMhqtANA0Gq0A0DUarQA="</v>
+          </d>
+        </o>
       </d>
       <d n="Values" t="Hashtable" />
     </o>
-        </Data>
-        <TypeList>
-          <Type n="Hashtable">System.Collections.Hashtable</Type>
-          <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
-          <Type n="String">System.String</Type>
-        </TypeList>
-      </XmlArchive>
+  </Data>
+  <TypeList>
+    <Type n="Boolean">System.Boolean</Type>
+    <Type n="Hashtable">System.Collections.Hashtable</Type>
+    <Type n="Int32">System.Int32</Type>
+    <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
+    <Type n="String">System.String</Type>
+  </TypeList>
+</XmlArchive>
     </PlcProjectOptions>
   </ProjectExtensions>
 </Project>

--- a/lcls-twincat-motion-example/tc_mot_example/tc_mot_example.tmc
+++ b/lcls-twincat-motion-example/tc_mot_example/tc_mot_example.tmc
@@ -1,6 +1,3687 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{04F5ADE1-B52F-4463-A8DC-3C87CD796D8D}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CEB668BE-884C-B71E-B393-44E389C01F5E}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
+    <DataType>
+      <Name GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>nTran</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xAttOK</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <Hides>
+        <Hide GUID="{76269EAC-36F0-4513-B811-3725FD02409A}"/>
+        <Hide GUID="{E96BEA56-6301-4A6A-BF6A-F08340C87594}"/>
+        <Hide GUID="{FE32F9A9-7E7A-413D-8D77-0C99C34D8CD9}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Attenuator</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</ExtendsType>
+    </DataType>
+    <DataType>
+      <Name GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Name>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>Width</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment> distance between horizontal slits (x)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Width
+            io: i
+            field: EGU mm</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Height</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment> distance between vertical slits (y)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Height
+            io: i
+            field: EGU mm</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOK</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <Comment> status of aperture, false if error or in motion</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: OK
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Aperture</Name>
+      <BitSize>96</BitSize>
+      <ExtendsType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</ExtendsType>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</Name>
+      <BitSize>1216</BitSize>
+      <SubItem>
+        <Name>nTran</Name>
+        <Type>UINT</Type>
+        <Comment>  Requested pre-optic attenuation %  </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Transmission
+            io: i
+            field: EGU %
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRate</Name>
+        <Type>UDINT</Type>
+        <Comment> Pulse-rate </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>120</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Rate
+            io: i
+            field: EGU Hz
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPP_mJ</Name>
+        <Type>REAL</Type>
+        <Comment> Per pulse max energy (mJ) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>20</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PulseEnergy
+            io: i
+            field: EGU mJ
+            field: DESC This beam parameter is non-op for now.
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neVRange</Name>
+        <Type>WORD</Type>
+        <Comment> Photon energy ranges </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>65535</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PhotonEnergyRanges
+            io: i
+            field: EGU eV</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astAttenuators</Name>
+        <Type Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Attenuator</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Beamline attenuators </Comment>
+        <BitSize>512</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: AuxAtt
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>aStoppers</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Stoppers </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: ST
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astApertures</Name>
+        <Type Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Aperture</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>4</Elements>
+        </ArrayInfo>
+        <Comment> Apertures </Comment>
+        <BitSize>384</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>[1].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[1].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>xValidToggle</Name>
+        <Type>BOOL</Type>
+        <Comment> Toggle for watchdog</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xValid</Name>
+        <Type>BOOL</Type>
+        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Valid
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCohortInt</Name>
+        <Type>UDINT</Type>
+        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Cohort
+        io: i
+            field: DESC Cohort inc on each arb cycle
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_PositionState</Name>
+      <BitSize>2432</BitSize>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Name as queried via the NAME PV in EPICS</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <String>Invalid</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: NAME
+        io: input
+        field: DESC Name of this position state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <Comment> Position associated with this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: SETPOINT
+        io: io
+        field: DESC Axis position associated with this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ENCODER
+        io: i
+        field: DESC Encoder count associated with this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <Comment> Maximum allowable deviation from fPosition while at the state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DELTA
+        io: io
+        field: DRVL 0.0
+        field: DESC Max deviation from position at this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <Comment> Speed at which to move to this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: VELO
+        io: io
+        field: DESC Speed at which to move to this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <Comment> (optional) Acceleration to use for moves to this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ACCL
+        io: io
+        field: DESC Acceleration to use for moves to this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDecel</Name>
+        <Type>LREAL</Type>
+        <Comment> (optional) Deceleration to use for moves to this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DCCL
+        io: io
+        field: DESC Deceleration to use for moves to this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOk</Name>
+        <Type>BOOL</Type>
+        <Comment> Safety parameter. This must be set to TRUE by the PLC program to allow moves to this state. This is expected to change as conditions change.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MOVE_OK
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if the move would be safe
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bLocked</Name>
+        <Type>BOOL</Type>
+        <Comment> Signifies to FB_PositionStateLock that this state should be immutable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: LOCKED
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if state is immutable
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE when you make your state. This defaults to FALSE so that uninitialized states can never be moved to</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: VALID
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if this is a real state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUseRawCounts</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE when you want to use the raw encoder counts to define the state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bUpdated</Name>
+        <Type>BOOL</Type>
+        <Comment> Is set to TRUE by FB_PositionStateInternal when called</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stBeamParams</Name>
+        <Type Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</Type>
+        <Comment> Beam parameters associated with this state</Comment>
+        <BitSize>1216</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.nTran</Name>
+            <Value>100</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fPP_mJ</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.neVRange</Name>
+            <Value>65535</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nRate</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[1].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[1].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[2].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[2].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[3].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[3].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[4].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.astApertures[4].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nRequestAssertionID</Name>
+        <Type>UDINT</Type>
+        <Comment> Transition ID associated with this state</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+      <BitSize>48</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+      <ArrayInfo>
+        <LBound>0</LBound>
+        <Elements>6</Elements>
+      </ArrayInfo>
+      <Format>
+        <Printf>%d.%d.%d.%d.%d.%d</Printf>
+        <Parameter>[0]</Parameter>
+        <Parameter>[1]</Parameter>
+        <Parameter>[2]</Parameter>
+        <Parameter>[3]</Parameter>
+        <Parameter>[4]</Parameter>
+        <Parameter>[5]</Parameter>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General">ST_System</Name>
+      <Comment>Defacto system structure, must be included in all projects</Comment>
+      <BitSize>88</BitSize>
+      <SubItem>
+        <Name>xSwAlmRst</Name>
+        <Type>BOOL</Type>
+        <Comment> Global Alarm Reset - EPICS Command </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xAtVacuum</Name>
+        <Type>BOOL</Type>
+        <Comment> System At Vacuum </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFirstScan</Name>
+        <Type>BOOL</Type>
+        <Comment> This boolean is true for the first scan, and is false thereafter, use for initialization of stuff </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment>This bit is set when using the override features of the system</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xIOState</Name>
+        <Type>BOOL</Type>
+        <Comment> ECat Bus Health </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>I_EcatMaster1</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+        <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
+        <BitSize>48</BitSize>
+        <BitOffs>40</BitOffs>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>omit</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_MaxString</Name>
+      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
+      <BitSize>2048</BitSize>
+      <BaseType>STRING(255)</BaseType>
+    </DataType>
+    <DataType>
+      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity*" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Verbose</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Info</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Warning</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Error</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Critical</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
+        <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General">E_Subsystem</Name>
+      <BitSize>16</BitSize>
+      <BaseType>WORD</BaseType>
+      <EnumInfo>
+        <Text>NILVALUE</Text>
+        <Enum>0</Enum>
+        <Comment>Undefined system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>VACUUM</Text>
+        <Enum>1</Enum>
+        <Comment>Vacuum control system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MPS</Text>
+        <Enum>2</Enum>
+        <Comment>Machine protection system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MOTION</Text>
+        <Enum>3</Enum>
+        <Comment>Motion control systems</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FIELDBUS</Text>
+        <Enum>4</Enum>
+        <Comment>EtherCAT networks</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>SDS</Text>
+        <Enum>5</Enum>
+        <Comment>Sample delivery system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OPTICS</Text>
+        <Enum>6</Enum>
+        <Comment>Optics control system</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{C3BF7AA5-0A83-4CFA-9A7A-04C1DFD0E5DD}" TcBaseType="true" CName="ITcAsyncResult*">ITcAsyncResult</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetIsBusy</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>bIsBusy</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}" ReferenceTo="true">BOOL32</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetHasError</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>bError</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}" ReferenceTo="true">BOOL32</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>hresult</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}" ReferenceTo="true">HRESULT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Name>
+      <BitSize>128</BitSize>
+      <PropertyItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <GetCodeOffs>79305488</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <GetCodeOffs>79305552</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79305568</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nStringSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79305536</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sResult</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79305560</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>bBusy</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>b32IsBusy</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Init</Name>
+        <Parameter>
+          <Name>ipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetString</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sResult</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResult</Name>
+          <Comment> buffer size in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__getnStringSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nStringSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getbError</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>b32HasError</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getsResult</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sResult</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>enable_dynamic_creation</Name>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+        <Property>
+          <Name>no_assign</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType*">TcSourceInfoType</Name>
+      <BitSize>32</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000008}">UDINT</BaseType>
+      <EnumInfo>
+        <Text>Undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Id</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Guid</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Name</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{3F74866B-4568-47E2-894F-D4B96829DBD0}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType*">TcSerializedSourceInfoType</Name>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>eType</Name>
+        <Type GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}">TcSourceInfoType</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>obData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>cbData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{F7BF6767-548B-493C-899B-06A477976F11}" TcBaseType="true" CName="ITcSourceInfo*">ITcSourceInfo</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetNumTypes</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nCount</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetTypes</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ppSourceInfoTypes</Name>
+          <Type GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" PointerTo="2" Const="1">TcSerializedSourceInfoType</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDataSize</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetData</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ppData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1" Const="1">PVOID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" TcBaseType="true" CName="ITcEvent*">ITcEvent</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetEventId</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetSeverity</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>severity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" ReferenceTo="true">TcEventSeverity</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetSourceInfo</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}" PointerTo="1">ITcSourceInfo</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type GUID="{18071995-0000-0000-0000-000100000050}" ReferenceTo="true">STRING(80)</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJsonAttribute</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetText</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}" PointerTo="1">ITcAsyncStringResult</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetEventClassName</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}" PointerTo="1">ITcAsyncStringResult</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getnId</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getsName</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry*">TcEventEntry</Name>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>uuidEventClass</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEventId</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eSeverity</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcEventBase</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getipSourceInfo</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getnEventId</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getsEventClassName</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getsEventText</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</ReturnType>
+        <ReturnBitSize>192</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EqualsToEventClass</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntry</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nOtherEventID</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eOtherSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntryEx</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>stOther</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJsonAttribute</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestEventClassName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestEventText</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name>IQueryInterface</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" TcBaseType="true" CName="TcEventArgumentType*">TcEventArgumentType</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>Undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Boolean</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int8</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int16</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int32</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int64</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt8</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt16</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt32</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt64</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Float</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Double</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Char</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WChar</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>StringType</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WStringType</Text>
+        <Enum>15</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EventReference</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FormatString</Text>
+        <Enum>17</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ExternalTimestamp</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Blob</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AdsNotificationStream</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UTF8EncodedString</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{A1C88D80-AC7F-419E-838D-233C8A8C0184}"/>
+        <Hide GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" TcBaseType="true" CName="ITcArguments*">ITcArguments</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>Count</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nCount</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddArgument</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}">TcEventArgumentType</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Get</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nIndex</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" ReferenceTo="true">TcEventArgumentType</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ppData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1" Const="1">PVOID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArgumentTypes</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pArgumentTypes</Name>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" PointerTo="1">TcEventArgumentType</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDataSize</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetData</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000001}" PointerTo="1">BYTE</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType>IQueryInterface</ExtendsType>
+      <Method>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>AddBlob</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>pData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddByte</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDWord</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceEx</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceId</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceIdGuid</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>EventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLReal</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddSInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddString</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddStringByValue</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUDInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddULInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUSInt</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUtf8EncodedString</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddWord</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddWString</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">WSTRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddWStringByValue</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Name>
+      <BitSize>2944</BitSize>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Implements>
+      <PropertyItem>
+        <Name>nId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79305368</GetCodeOffs>
+        <SetCodeOffs>79305416</SetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sName</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79305440</GetCodeOffs>
+        <SetCodeOffs>79305464</SetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>__setbCutInstancePathByLastInst</Name>
+        <Parameter>
+          <Name>bCutInstancePathByLastInst</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+      </Method>
+      <Method>
+        <Name>ExtendName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sExtension</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipData</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="3">__getnId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ResetToDefault</Name>
+        <Local>
+          <Name>_sInstancePath</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
+        <Parameter>
+          <Name>nId</Name>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>monitoring</Name>
+              <Value>call</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__setguid</Name>
+        <Parameter>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sName</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="12">__setsName</Name>
+        <Parameter>
+          <Name>sName</Name>
+          <Type RpcDirection="in">STRING(255)</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>monitoring</Name>
+              <Value>call</Value>
+            </Property>
+            <Property>
+              <Name>TcEncoding</Name>
+              <Value>UTF-8</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcEventBase</Name>
+      <BitSize>4032</BitSize>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Implements>
+      <SubItem>
+        <Name>fbSourceInfo</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
+        <BitSize>2944</BitSize>
+        <BitOffs>512</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.bCutInstancePathByLastInst</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__FBRESULT</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>3648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__BBUSY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTTEXT__FBRESULT</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>3840</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTTEXT__BBUSY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3968</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <PropertyItem>
+        <Name>eSeverity</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <GetCodeOffs>79305664</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>ipSourceInfo</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+        <BitSize>64</BitSize>
+        <GetCodeOffs>79305624</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nEventId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79305800</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sEventClassName</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79305720</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sEventText</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79305808</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>EqualsToEventClass</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Local>
+          <Name>_EventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetEventClassName</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>fbResult</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_AsyncStrResult</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Release</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>EventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>eSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</ReturnType>
+        <ReturnBitSize>192</ReturnBitSize>
+        <Local>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>OnCreate</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntry</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nOtherEventID</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eOtherSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestEventText</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>fbResult</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTTEXT__FBRESULT</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>bBusy</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTTEXT__BBUSY</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventClassName</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getipArguments</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetEventText</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>fbResult</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_AsyncStrResult</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJsonAttribute</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>RequestEventClassName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>fbResult</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__FBRESULT</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>bBusy</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__BBUSY</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntryEx</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>stOther</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEventId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="11">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventText</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+        <Property>
+          <Name>no_assign</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcMessage</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcEventBase</ExtendsType>
+      <Method>
+        <Name>Send</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nTimeStamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}" TcBaseType="true" CName="ITcMessage*">ITcMessage</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</BaseType>
+      <Method>
+        <Name>SetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000001A}">PCCH</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArguments</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" PointerTo="1">ITcArguments</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Send</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>timeStamp</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{77D5D639-16DD-48F7-8490-F632AA095917}" TcBaseType="true" CName="ITcMessage2*">ITcMessage2</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</BaseType>
+      <Method>
+        <Name>GetTimeSent</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>timeStamp</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000B}" ReferenceTo="true">ULINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcMessage</Name>
+      <BitSize>4160</BitSize>
+      <ExtendsType Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcEventBase</ExtendsType>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcMessage</Implements>
+      <PropertyItem>
+        <Name>nTimeSent</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <GetCodeOffs>79305864</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>SetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CreateEx</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ipSourceInfo</Name>
+          <Comment> optional (otherwise a default source info is taken)</Comment>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Init</Name>
+        <Parameter>
+          <Name>ipMessage</Name>
+          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="45">__getnTimeSent</Name>
+        <ReturnType RpcDirection="out">ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>nTimeSent</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipMessage2</Name>
+          <Type GUID="{77D5D639-16DD-48F7-8490-F632AA095917}">ITcMessage2</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>nTimeStamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcDisplayTypeGUID</Name>
+            <Value>18071995-0000-0000-0000-000000000046</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Create</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ipSourceInfo</Name>
+          <Comment> optional (otherwise a default source info is taken)</Comment>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Send</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nTimeStamp</Name>
+          <Comment> set 0 to get the current time automatically</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>TcEncoding</Name>
+              <Value>FILETIME</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Release</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">F_TRIG</Name>
+      <Comment>
+	Falling Edge detection.
+</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> falling edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">R_TRIG</Name>
+      <Comment>
+	Rising Edge detection.
+</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> Signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> rising edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Name>
+      <BitSize>85696</BitSize>
+      <SubItem>
+        <Name>sMsg</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Message to send</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eSevr</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2112</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eSubsystem</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General">E_Subsystem</Type>
+        <Comment> Subsystem</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sJson</Name>
+        <Type>STRING(7000)</Type>
+        <Comment> JSON to add to the message</Comment>
+        <BitSize>56008</BitSize>
+        <BitOffs>2144</BitOffs>
+        <Default>
+          <String>{}</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMinTimeViolationAcceptable</Name>
+        <Type>INT</Type>
+        <Comment> How many times the min. time can be violated before the CB trips</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>58160</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLocalTripThreshold</Name>
+        <Type>TIME</Type>
+        <Comment> Minimum time between calls allowed, pairs with nMinTimeViolationAcceptable</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58176</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTrickleTripThreshold</Name>
+        <Type>TIME</Type>
+        <Comment> Trickle trip, activated by global threshold, should be &gt;&gt; LocalTripThreshold</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58208</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTripResetPeriod</Name>
+        <Type>TIME</Type>
+        <Comment> Time for auto-reset</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58240</BitOffs>
+        <Default>
+          <Value>600000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableAutoReset</Name>
+        <Type>BOOL</Type>
+        <Comment>Enable circuit breaker auto-reset (true by default)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>58272</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInitialized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>58280</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bInitFailed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>58288</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>sSubsystemSource</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>58296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMessage</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcMessage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>58944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMessages</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>5</Elements>
+        </ArrayInfo>
+        <BitSize>20800</BitSize>
+        <BitOffs>59008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbSource</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
+        <BitSize>2944</BitSize>
+        <BitOffs>79808</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ipResultMessage</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>82752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>hr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>82816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>hrLastInternalError</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>82848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eTraceLevel</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>82880</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCall</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>82896</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>82904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTotalEvents</Name>
+        <Type>UINT</Type>
+        <Comment>////////////////////////////</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>84960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTimesViolated</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>84976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LastCallTime</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>84992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CurrentCallTime</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>85056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DeltaSinceLastCall</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>85120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WhenTripsCleared</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>85184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftTrippedReleased</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>85248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLocalTrickleTripped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>85376</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLocalTripped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>85384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bTripped</Name>
+        <Type>BOOL</Type>
+        <Comment> Won't emit messages if true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>85392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+            pv: Tripped
+            io: i
+            field: DESC Log message FB tripped
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetBreaker</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>85400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+            pv: Reset
+            io: o
+            field: DESC Rising-edge reset of trip
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtResetBreaker</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>85440</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTripped</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>85568</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>CircuitBreaker</Name>
+      </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
     <DataType>
       <Name GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}" TcBaseType="true">ST_LibVersion</Name>
       <BitSize>288</BitSize>
@@ -57,6 +3738,21 @@
         <Text>eWATCHDOG_TIME_MINUTES</Text>
         <Enum>2</Enum>
       </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>INT (2..100)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>2</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_Utilities">E_HashPrefixTypes</Name>
@@ -386,7 +4082,7 @@
       <SubItem>
         <Name>wMinute</Name>
         <Type>WORD</Type>
-        <Comment> Munute: 0..59 </Comment>
+        <Comment> Minute: 0..59 </Comment>
         <BitSize>16</BitSize>
         <BitOffs>80</BitOffs>
       </SubItem>
@@ -463,6 +4159,8886 @@
         <BitSize>32</BitSize>
         <BitOffs>832</BitOffs>
       </SubItem>
+    </DataType>
+    <DataType>
+      <Name>UDINT (81..Tc2_Utilities.ParameterList.cMaxCharacters)</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>81</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>10000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>0</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>1000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>0</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_AssertionType</Name>
+      <BitSize>8</BitSize>
+      <BaseType>BYTE</BaseType>
+      <EnumInfo>
+        <Text>Type_UNDEFINED</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_ANY</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_BOOL</Text>
+        <Enum>2</Enum>
+        <Comment> Primitive types </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_BYTE</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DATE</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DATE_AND_TIME</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DINT</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DWORD</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_INT</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LINT</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LREAL</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LTIME</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LWORD</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_REAL</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_SINT</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_STRING</Text>
+        <Enum>15</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_TIME</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_TIME_OF_DAY</Text>
+        <Enum>17</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_UDINT</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_UINT</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_ULINT</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_USINT</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_WORD</Text>
+        <Enum>22</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_WSTRING</Text>
+        <Enum>23</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array2D_LREAL</Text>
+        <Enum>24</Enum>
+        <Comment> Array types </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array2D_REAL</Text>
+        <Enum>25</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array3D_LREAL</Text>
+        <Enum>26</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array3D_REAL</Text>
+        <Enum>27</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_BOOL</Text>
+        <Enum>28</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_BYTE</Text>
+        <Enum>29</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_DINT</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_DWORD</Text>
+        <Enum>31</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_INT</Text>
+        <Enum>32</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_LINT</Text>
+        <Enum>33</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_LREAL</Text>
+        <Enum>34</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_LWORD</Text>
+        <Enum>35</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_REAL</Text>
+        <Enum>36</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_SINT</Text>
+        <Enum>37</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_UDINT</Text>
+        <Enum>38</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_UINT</Text>
+        <Enum>39</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_ULINT</Text>
+        <Enum>40</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_USINT</Text>
+        <Enum>41</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_WORD</Text>
+        <Enum>42</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_TestCaseResult</Name>
+      <BitSize>6192</BitSize>
+      <SubItem>
+        <Name>TestName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestClassName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsFailed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsSkipped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FailureMessage</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>4112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FailureType</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_AssertionType</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfAsserts</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>6176</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_TestSuiteResult</Name>
+      <BitSize>621296</BitSize>
+      <SubItem>
+        <Name>Name</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Full class name</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Identity</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <Comment> Should be 0..GVL_Param_TcUnit.MaxNumberOfTestSuites-1 but gives unknown compiler error</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfTests</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfFailedTests</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestCaseResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_TestCaseResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>100</Elements>
+        </ArrayInfo>
+        <BitSize>619200</BitSize>
+        <BitOffs>2096</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_TestSuiteResults</Name>
+      <BitSize>621296064</BitSize>
+      <SubItem>
+        <Name>NumberOfTestSuites</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test suites</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfTestCases</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test cases (for all test suites)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfSuccessfulTestCases</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test cases that had all ASSERTS successful</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfFailedTestCases</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test cases that had at least one ASSERT failed</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestSuiteResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_TestSuiteResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> Test results for each individiual test suite </Comment>
+        <BitSize>621296000</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResults</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>GetAreTestResultsAvailable</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestSuiteResults</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>1000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TestResults</Name>
+      <Comment> This function block holds results of the complete test run, i.e. results for all test suites </Comment>
+      <BitSize>621296448</BitSize>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResults</Implements>
+      <SubItem>
+        <Name>TestSuiteResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_TestSuiteResults</Type>
+        <Comment> Test results </Comment>
+        <BitSize>621296064</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StoringTestSuiteResultNumber</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <Comment> Misc variables </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>621296192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StoringTestSuiteTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>621296256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StoredTestSuiteResults</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>621296384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StoredGeneralTestResults</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>621296392</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>GetAreTestResultsAvailable</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestSuiteResults</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResultLogger</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>LogTestSuiteResults</Name>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdsTestResultLogger</Name>
+      <Comment>
+    This function block reports the results from the tests using the built-in ADSLOGSTR functionality
+    provided by the Tc2_System library. This sends the result using ADS, which is consumed by the "Error List"
+    of Visual Studio (which can print Errors, Warnings and Messages).
+</Comment>
+      <BitSize>448</BitSize>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResultLogger</Implements>
+      <SubItem>
+        <Name>TestResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResults</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintingTestSuiteResultNumber</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintingTestSuiteTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintedFinalTestResults</Name>
+        <Type>BOOL</Type>
+        <Comment> This flag is set once the final end result has printed </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintedTestSuitesResults</Name>
+        <Type>BOOL</Type>
+        <Comment> This flag is set once the test suites result have been printed </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>392</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>LogTestSuiteResults</Name>
+        <Local>
+          <Name>TcUnitTestResults</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>StringToPrint</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TestsInTestSuiteCounter</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_SKIP</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_PASS</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_FAIL</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysFile">ACCESS_MODE</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+      <EnumInfo>
+        <Text>AM_READ</Text>
+        <Enum>0</Enum>
+        <Comment> Open an existing file with Read access. If file does not exist, Open fails</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_WRITE</Text>
+        <Enum>1</Enum>
+        <Comment> Create new file with Write access. If file does exist, content is discarded</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_APPEND</Text>
+        <Enum>2</Enum>
+        <Comment> Open an existing file with Append (only write) access. If file does not exist, Open fails</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_READ_PLUS</Text>
+        <Enum>3</Enum>
+        <Comment> Open an existing file with Read/Write access. If file does not exist, Open fails</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_WRITE_PLUS</Text>
+        <Enum>4</Enum>
+        <Comment> Create new file with Read/Write access. If file does exist, content is discarded</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_APPEND_PLUS</Text>
+        <Enum>5</Enum>
+        <Comment> Open an existing file with Append (read/write) access. If file does not exist, Open creates a new file</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_SIZE</Name>
+      <BitSize>64</BitSize>
+      <BaseType PointerTo="1">BYTE</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_HANDLE</Name>
+      <BitSize>64</BitSize>
+      <BaseType PointerTo="1">BYTE</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_FileControl</Name>
+      <Comment>
+    This functionblock can open, close, read, write and delete files on the local filesystem
+</Comment>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>FileAccessMode</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+        <Comment> Append_Plus creates the file if it doesn't exist yet. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FileHandle</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_HANDLE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Read</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF(); </Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>FileSize</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_SIZE</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Close</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Open</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Delete</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a forward slash (/) </Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Write</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_XmlError</Name>
+      <BitSize>8</BitSize>
+      <BaseType>BYTE</BaseType>
+      <EnumInfo>
+        <Text>Ok</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ErrorMaxBufferLen</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ErrorStringLen</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Error</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_StreamBuffer</Name>
+      <Comment>
+    This functionblock acts as a stream buffer for use with FB_XmlControl
+</Comment>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>_PointerToStringBuffer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>_BufferSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>_Length</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>CutOff</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>StartPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>CutLen</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>XmlError</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_XmlError</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToByteToCut</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Find</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>SearchString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>StartPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Search</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToSearch</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>FindBack</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>SearchString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Search</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToSearch</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Copy</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>StartPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>EndPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>CopyLen</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>XmlError</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_XmlError</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToByteToCopy</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>CurPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_XmlControl</Name>
+      <Comment>
+    Organizes parsing and composing of XML data. Data can be treated as STRING or char array.
+    Buffer size of file can be set via GVL_Param_TcUnit (xUnitBufferSize)
+</Comment>
+      <BitSize>6016</BitSize>
+      <SubItem>
+        <Name>XmlBuffer</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagListBuffer</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Tags</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagListSeekBuffer</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>2496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagsSeek</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>2688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagBuffer</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>3392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Tag</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>3584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagOpen</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Select</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SearchPosition</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TAG_OPEN</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5728</BitOffs>
+        <Default>
+          <String>&lt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TAG_CLOSE</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5744</BitOffs>
+        <Default>
+          <String>&gt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>END_TAG_CLOSE</Name>
+        <Type>STRING(2)</Type>
+        <BitSize>24</BitSize>
+        <BitOffs>5760</BitOffs>
+        <Default>
+          <String>/&gt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>SPACE</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5784</BitOffs>
+        <Default>
+          <String> </String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>EQUALS</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5800</BitOffs>
+        <Default>
+          <String>=</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>QUOTE</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5816</BitOffs>
+        <Default>
+          <String>"</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>BACK_SLASH</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5832</BitOffs>
+        <Default>
+          <String>\</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FORWARD_SLASH</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5848</BitOffs>
+        <Default>
+          <String>/</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>OPEN_COMMENT</Name>
+        <Type>STRING(5)</Type>
+        <BitSize>48</BitSize>
+        <BitOffs>5864</BitOffs>
+        <Default>
+          <String>&lt;!-- </String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>CLOSE_COMMENT</Name>
+        <Type>STRING(4)</Type>
+        <BitSize>40</BitSize>
+        <BitOffs>5912</BitOffs>
+        <Default>
+          <String> --&gt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TAB</Name>
+        <Type>STRING(2)</Type>
+        <BitSize>24</BitSize>
+        <BitOffs>5952</BitOffs>
+        <Default>
+          <String>	</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>CR_LF</Name>
+        <Type>STRING(4)</Type>
+        <BitSize>40</BitSize>
+        <BitOffs>5976</BitOffs>
+        <Default>
+          <String>
+</String>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>NewParameter</Name>
+        <Parameter>
+          <Name>Name</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Value</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewTag</Name>
+        <Parameter>
+          <Name>Name</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CloseTag</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>ClosedTag</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewTagData</Name>
+        <Parameter>
+          <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <Parameter>
+          <Name>PointerToBuffer</Name>
+          <Comment> ADR(..)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> SIZEOF(..)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ClearBuffer</Name>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_xUnitXmlPublisher</Name>
+      <Comment>
+    Publishes test results into an xUnit compatible Xml file
+</Comment>
+      <BitSize>530944</BitSize>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResultLogger</Implements>
+      <SubItem>
+        <Name>TestResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResults</Type>
+        <Comment> Dependancy Injection via FB_Init</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AccessMode</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+        <Comment> File access mode</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>File</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_FileControl</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Xml</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_XmlControl</Type>
+        <BitSize>6016</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BufferInitialised</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6464</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Buffer</Name>
+        <Type>BYTE</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>65535</Elements>
+        </ArrayInfo>
+        <BitSize>524280</BitSize>
+        <BitOffs>6472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WritingTestSuiteResultNumber</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>530752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PublishTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>530816</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>DeleteOpenWriteClose</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>LogTestSuiteResults</Name>
+        <Local>
+          <Name>UnitTestResults</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentSuiteNumber</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentTestCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_SKIP</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_PASS</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_FAIL</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Initialised</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TcUnitRunner</Name>
+      <Comment>
+    This function block is responsible for holding track of the tests and executing them.
+</Comment>
+      <BitSize>621828160</BitSize>
+      <SubItem>
+        <Name>AllTestSuitesFinished</Name>
+        <Type>BOOL</Type>
+        <Comment> Indication of whether all test suites have reported that they are finished </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TestResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TestResults</Type>
+        <Comment> Test result information </Comment>
+        <BitSize>621296448</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AdsTestResultLogger</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdsTestResultLogger</Type>
+        <Comment> Prints the results to ADS so that Visual Studio can display the results.
+       This test result formatter can be replaced with something else than ADS </Comment>
+        <BitSize>448</BitSize>
+        <BitOffs>621296576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TestResultLogger</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResultLogger</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>621297024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AbortRunningTestSuites</Name>
+        <Type>BOOL</Type>
+        <Comment> If this flag is set, it means that some external event triggered the
+       request to abort running the test suites </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>621297088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xUnitXmlPublisher</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_xUnitXmlPublisher</Type>
+        <Comment> Publishes a xUnit compatible XML file </Comment>
+        <BitSize>530944</BitSize>
+        <BitOffs>621297152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>XmlTestResultPublisher</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_TestResultLogger</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>621828096</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AbortRunningTestSuiteTests</Name>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RunTestSuiteTests</Name>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>BusyPrinting</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestSuitesFinished</Name>
+          <Comment> We need to hold a temporary state of the statistics 
+       as we don't consider the tests to be completely finished until all test suites have executed completely.
+       The reason we want to do it this way is because a test suite can run over several cycles. Only once all tests
+       are finished (which might take many cycles), do we gather correct statistics </Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>TYPE_CLASS</Name>
+      <BitSize>32</BitSize>
+      <BaseType>DWORD</BaseType>
+      <EnumInfo>
+        <Text>TYPE_BOOL</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_BIT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_BYTE</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_WORD</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DWORD</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LWORD</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_SINT</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_INT</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DINT</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LINT</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_USINT</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_UINT</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_UDINT</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ULINT</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_REAL</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LREAL</Text>
+        <Enum>15</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_STRING</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_WSTRING</Text>
+        <Enum>17</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_TIME</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DATE</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DATEANDTIME</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_TIMEOFDAY</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_POINTER</Text>
+        <Enum>22</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_REFERENCE</Text>
+        <Enum>23</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_SUBRANGE</Text>
+        <Enum>24</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ENUM</Text>
+        <Enum>25</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ARRAY</Text>
+        <Enum>26</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_PARAMS</Text>
+        <Enum>27</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_USERDEF</Text>
+        <Enum>28</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_NONE</Text>
+        <Enum>29</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANY</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYBIT</Text>
+        <Enum>31</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYDATE</Text>
+        <Enum>32</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYINT</Text>
+        <Enum>33</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYNUM</Text>
+        <Enum>34</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYREAL</Text>
+        <Enum>35</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LAZY</Text>
+        <Enum>36</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LTIME</Text>
+        <Enum>37</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_BITCONST</Text>
+        <Enum>38</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>AnyType</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>pValue</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diSize</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TypeClass</Name>
+        <Type>TYPE_CLASS</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>linkalways</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_Utilities">E_TypeFieldParam</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>TYPEFIELD_UNKNOWN</Text>
+        <Enum>0</Enum>
+        <Comment> Unknown/not set </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_B</Text>
+        <Enum>1</Enum>
+        <Comment> b or B: binary number </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_O</Text>
+        <Enum>2</Enum>
+        <Comment> o or O: octal number </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_U</Text>
+        <Enum>3</Enum>
+        <Comment> u or U: unsigned decimal number </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_C</Text>
+        <Enum>4</Enum>
+        <Comment> c or C: one ASCII character </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_F</Text>
+        <Enum>5</Enum>
+        <Comment> f or F: float number ( normalized format )</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_D</Text>
+        <Enum>6</Enum>
+        <Comment> d or D: signed decimal number  </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_S</Text>
+        <Enum>7</Enum>
+        <Comment> s or S: string </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_XU</Text>
+        <Enum>8</Enum>
+        <Comment> X: hecadecimal number (upper case characters )</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_XL</Text>
+        <Enum>9</Enum>
+        <Comment> x: hecadecimal number (lower case characters )</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_EU</Text>
+        <Enum>10</Enum>
+        <Comment> E: float number ( scientific format ) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPEFIELD_EL</Text>
+        <Enum>11</Enum>
+        <Comment> e: float number ( scientific format ) </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_Utilities">ST_FormatParameters</Name>
+      <BitSize>160</BitSize>
+      <SubItem>
+        <Name>bPercent</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFlags</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bWidth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDot</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bPrecision</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bType</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>40</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAlign</Name>
+        <Type>BOOL</Type>
+        <Comment> Default :Right align </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bSign</Name>
+        <Type>BOOL</Type>
+        <Comment> Default: Sign only for negative values </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>56</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNull</Name>
+        <Type>BOOL</Type>
+        <Comment> Default: No padding </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBlank</Name>
+        <Type>BOOL</Type>
+        <Comment> Default: No blanks</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHash</Name>
+        <Type>BOOL</Type>
+        <Comment> Default: No blanks </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iWidth</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iPrecision</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bWidthAsterisk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bPrecisionAsterisk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eType</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">E_TypeFieldParam</Type>
+        <Comment> format type parameter </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_Utilities">FB_FormatString</Name>
+      <Comment> Converts and formats up to 10 T_Arg values to string </Comment>
+      <BitSize>8576</BitSize>
+      <SubItem>
+        <Name>sFormat</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Format string </Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg1</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 1, use F_INT, F_UINT; F_WORD, F_DWORD, F_LREAL... functions to initialize the argument inputs </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg2</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 2 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg3</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 3 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2368</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg4</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 4 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg5</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 5 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg6</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 6 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg7</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 7 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>2880</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg8</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 8 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>3008</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg9</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 9 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>3136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arg10</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">T_Arg</Type>
+        <Comment> Format argument 10 </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>3264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE =&gt; error, FALSE =&gt; no error </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>3392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sOut</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Output stirng </Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>3456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pFormat</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>5504</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pOut</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>5568</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iRemOutLen</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5632</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stFmt</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">ST_FormatParameters</Type>
+        <BitSize>160</BitSize>
+        <BitOffs>5664</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nArrayElem</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5824</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nArgument</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>parArgs</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities" PointerTo="1">T_Arg</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>10</Elements>
+        </ArrayInfo>
+        <BitSize>640</BitSize>
+        <BitOffs>5888</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sArgStr</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>6528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_Test</Name>
+      <Comment>
+    This function block holds all data that defines a test.
+</Comment>
+      <BitSize>4224</BitSize>
+      <SubItem>
+        <Name>TestName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsFinished</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsSkipped</Name>
+        <Type>BOOL</Type>
+        <Comment> This is set to true, if test is disabled (by putting the string "disabled_" in front of the test name</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfAssertions</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsFailed</Name>
+        <Type>BOOL</Type>
+        <Comment> Indication of whether this test has at least one failed assert</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertionMessage</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Assertion message for the first assertion in this test</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>2152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertionType</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_AssertionType</Type>
+        <Comment> Assertion type for the first assertion in this test</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4200</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetAssertionType</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_AssertionType</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
+        <Name>SetName</Name>
+        <Parameter>
+          <Name>Name</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetName</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsSkipped</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAssertionMessage</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetSkipped</Name>
+      </Method>
+      <Method>
+        <Name>SetAssertionMessage</Name>
+        <Parameter>
+          <Name>AssertMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAssertionType</Name>
+        <Parameter>
+          <Name>AssertType</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>UINT (1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>TYPE_BOOL</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_BIT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_BYTE</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_WORD</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DWORD</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LWORD</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_SINT</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_INT</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DINT</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LINT</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_USINT</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_UINT</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_UDINT</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ULINT</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_REAL</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LREAL</Text>
+        <Enum>15</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_STRING</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_WSTRING</Text>
+        <Enum>17</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_TIME</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DATE</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_DATEANDTIME</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_TIMEOFDAY</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_POINTER</Text>
+        <Enum>22</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_REFERENCE</Text>
+        <Enum>23</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_SUBRANGE</Text>
+        <Enum>24</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ENUM</Text>
+        <Enum>25</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ARRAY</Text>
+        <Enum>26</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_PARAMS</Text>
+        <Enum>27</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_USERDEF</Text>
+        <Enum>28</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_NONE</Text>
+        <Enum>29</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANY</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYBIT</Text>
+        <Enum>31</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYDATE</Text>
+        <Enum>32</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYINT</Text>
+        <Enum>33</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYNUM</Text>
+        <Enum>34</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_ANYREAL</Text>
+        <Enum>35</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LAZY</Text>
+        <Enum>36</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_LTIME</Text>
+        <Enum>37</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_BITCONST</Text>
+        <Enum>38</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TYPE_INTERFACE</Text>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">U_ExpectedOrActual</Name>
+      <BitSize>4096</BitSize>
+      <SubItem>
+        <Name>boolExpectedOrActual</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bitExpectedOrActual</Name>
+        <Type>BIT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>byteExpectedOrActual</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sintExpectedOrActual</Name>
+        <Type>SINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>usintExpectedOrActual</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>intExpectedOrActual</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>uintExpectedOrActual</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wordExpectedOrActual</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwordExpectedOrActual</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dateandtimeExpectedOrActual</Name>
+        <Type>DATE_AND_TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dintExpectedOrActual</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>realExpectedOrActual</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timeExpectedOrActual</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dateExpectedOrActual</Name>
+        <Type>DATE</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>udintExpectedOrActual</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timeofdayExpectedOrActual</Name>
+        <Type>TIME_OF_DAY</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lwordExpectedOrActual</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lintExpectedOrActual</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ulintExpectedOrActual</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrealExpectedOrActual</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ltimeExpectedOrActual</Name>
+        <Type>LTIME</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stringExpectedOrActual</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wstringExpectedOrActual</Name>
+        <Type>WSTRING(255)</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertResult</Name>
+      <BitSize>12288</BitSize>
+      <SubItem>
+        <Name>Expected</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">U_ExpectedOrActual</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Actual</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">U_ExpectedOrActual</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>4096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Message</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>8192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestInstancePath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>10240</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertResultInstances</Name>
+      <BitSize>12352</BitSize>
+      <SubItem>
+        <Name>AssertResult</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertResult</Type>
+        <BitSize>12288</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DetectionCount</Name>
+        <Type>UINT</Type>
+        <Comment> Number of instances of the "AssertResult"</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DetectionCountThisCycle</Name>
+        <Type>UINT</Type>
+        <Comment> Number of instance of the "AssertResult" in this specific PLC-cycle</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12304</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AssertResultStatic</Name>
+      <Comment>
+    This function block is responsible for keeping track of which asserts that have been made. The reason we need to
+    keep track of these is because if the user does the same assert twice (because of running a test suite over several
+    PLC-cycles) we want to know it so we don't print several times (if the assert fails).
+    An instance of an assert is keyed/identified with the following parameters as key:
+    - Value of expected
+    - Value of actual
+    - Message (string)
+    - Test instance path (string)
+</Comment>
+      <BitSize>24640448</BitSize>
+      <SubItem>
+        <Name>AssertResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> The total number of instances of each of the "AssertResults" </Comment>
+        <BitSize>12288000</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TotalAsserts</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of unique asserts </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12288064</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>GetCurrentTaskIndex</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <Comment> Function block to get the current task cycle </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>12288128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertResultInstances</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertResultInstances</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> The total number of instances of each of the "AssertResults" </Comment>
+        <BitSize>12352000</BitSize>
+        <BitOffs>12288384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleCount</Name>
+        <Type>UDINT</Type>
+        <Comment> The last PLC cycle count </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>24640384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FirstCycleExecuted</Name>
+        <Type>BOOL</Type>
+        <Comment> Only run first cycle </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24640416</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfAssertsForTest</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCount</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>ReportResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>LocationIndex</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DataTypesNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataSizeNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataContentNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentCycleCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DetectionCountTemp</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>FoundOne</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>AdditionalIdenticalAssert</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertArrayResult</Name>
+      <BitSize>4224</BitSize>
+      <SubItem>
+        <Name>ExpectedsSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Size in bytes of the expecteds-array</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExpectedsTypeClass</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Comment> The data type of the expecteds-array</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActualsSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Size in bytes of the actuals-array</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActualsTypeClass</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Comment> The data type of the actuals-array</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Message</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestInstancePath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>2160</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertArrayResultInstances</Name>
+      <BitSize>4256</BitSize>
+      <SubItem>
+        <Name>AssertArrayResult</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertArrayResult</Type>
+        <BitSize>4224</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DetectionCount</Name>
+        <Type>UINT</Type>
+        <Comment> Number of instances of the "AssertArrayResult"</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>4224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DetectionCountThisCycle</Name>
+        <Type>UINT</Type>
+        <Comment> Number of instance of the "AssertArrayResult" in this specific PLC-cycle</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>4240</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AssertArrayResultStatic</Name>
+      <Comment>
+    This function block is responsible for keeping track of which array-asserts that have been made.
+    The reason we need to keep track of these is because if the user does the same assert twice
+    (because of running a test suite over several PLC-cycles) we want to know it so we don't print several times
+    (if the assert fails). An instance of an array-assert is keyed/identified with the following parameters as key:
+    - Array-size (in bytes) of the expecteds
+    - Datatype of the expecteds
+    - Array-size (in bytes) of the actuals
+    - Datatype of the actuals
+    - Message (string)
+    - Test instance path (string)
+</Comment>
+      <BitSize>8480448</BitSize>
+      <SubItem>
+        <Name>AssertArrayResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertArrayResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> The total number of instances of each of the "AssertArrayResults" </Comment>
+        <BitSize>4224000</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TotalArrayAsserts</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of unique asserts </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>4224064</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>GetCurrentTaskIndex</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <Comment> Function block to get the current task cycle </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>4224128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertArrayResultInstances</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AssertArrayResultInstances</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> The total number of instances of each of the "AssertArrayResults" </Comment>
+        <BitSize>4256000</BitSize>
+        <BitOffs>4224384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleCount</Name>
+        <Type>UDINT</Type>
+        <Comment> The last PLC cycle count </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8480384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FirstCycleExecuted</Name>
+        <Type>BOOL</Type>
+        <Comment> Only run first cycle </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8480416</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCount</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>ReportResult</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>LocationIndex</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DataTypesNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataSizeNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataContentNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentCycleCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DetectionCountTemp</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>FoundOne</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>AdditionalIdenticalAssert</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfArrayAssertsForTest</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfArrayAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddAssertArrayResult</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_AssertMessageFormatter</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>LogAssertFailure</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
+      <Comment>
+    This function block is responsible for making sure that the asserted test instance path and test message are not
+    loo long. The total printed message can not be more than 253 characters long.
+</Comment>
+      <BitSize>11648</BitSize>
+      <SubItem>
+        <Name>MsgFmtString</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Test instance path</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>StringArg</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Test message</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>2112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MsgFmtStringProcessed</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>4160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>StringArgProcessed</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>6208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MsgFmtStringTemp</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>8256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestNameTooLong</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>10304</BitOffs>
+        <Default>
+          <String>...TestName too long</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TestMsgTooLong</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>10952</BitOffs>
+        <Default>
+          <String>...TestMsg too long</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>MSG_FMT_STRING_MAX_NUMBER_OF_CHARACTERS</Name>
+        <Type>INT</Type>
+        <Comment> This is actually 254, but if StrArg-argument is used (which it is in TcUnit) it is 253.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>11600</BitOffs>
+        <Default>
+          <Value>253</Value>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdsAssertMessageFormatter</Name>
+      <Comment>
+    This function block is responsible for printing the results of the assertions using the built-in
+    ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
+    is consumed by the error list of Visual Studio.
+</Comment>
+      <BitSize>128</BitSize>
+      <Implements Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_AssertMessageFormatter</Implements>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>LogAssertFailure</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AdjustAssertFailureMessageToMax253CharLength</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
+          <BitSize>11648</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePathCleaned</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePathFinal</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ReturnValue</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePathProcessed</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>MessageProcessed</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TestSuite</Name>
+      <Comment> This function block is responsible for holding the internal state of the test suite.
+   Every test suite can have one or more tests, and every test can do one or more asserts.
+   It's also responsible for providing all the assert-methods for asserting different data types.
+   Only failed assertions are recorded.
+</Comment>
+      <BitSize>33561920</BitSize>
+      <SubItem>
+        <Name>InstancePath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GetCurrentTaskIndex</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <Comment> We need to have access to specific information of the current task that this test suite
+       is executed in. This is for instance necessary when we need to know whether a test is
+       defined already. The definition of a test that is defined already is that we call on it
+       with the same name twice in the same cycle </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfTests</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2368</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Tests</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_Test</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>100</Elements>
+        </ArrayInfo>
+        <BitSize>422400</BitSize>
+        <BitOffs>2432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestDuplicateNameTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>100</Elements>
+        </ArrayInfo>
+        <Comment> Rising trigger of whether we have already notified the user of that the test name pointed to by the current
+       position is a duplicate </Comment>
+        <BitSize>12800</BitSize>
+        <BitOffs>424832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestCycleCountIndex</Name>
+        <Type>UDINT</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>100</Elements>
+        </ArrayInfo>
+        <Comment> Last cycle count index for a specific test. Used to detect whether this test has already been defined in the
+       current test suite </Comment>
+        <BitSize>3200</BitSize>
+        <BitOffs>437632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AssertResultStatic</Type>
+        <BitSize>24640448</BitSize>
+        <BitOffs>440832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertArrayResults</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AssertArrayResultStatic</Type>
+        <BitSize>8480448</BitSize>
+        <BitOffs>25081280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AdsAssertMessageFormatter</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdsAssertMessageFormatter</Type>
+        <Comment> Prints the failed asserts to ADS so that Visual Studio can display the assert message.
+       This assert formatter can be replaced with something else than ADS </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>33561728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertMessageFormatter</Name>
+        <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">I_AssertMessageFormatter</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>33561856</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>AssertArrayEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_WORD</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> WORD array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">WORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> WORD array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">WORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CalculateAndSetNumberOfAssertsForTest</Name>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TotalNumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfArrayAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_WORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> WORD expected value</Comment>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> WORD actual value</Comment>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> ULINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">ULINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> ULINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">ULINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LINT expected value</Comment>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LINT actual value</Comment>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> Expected value</Comment>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> The value to check against expected</Comment>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Count</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedDataString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualDataString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>boolExpected</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>boolActual</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>byteExpected</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>byteActual</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>dateExpected</Name>
+          <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dateActual</Name>
+          <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dateAndTimeExpected</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dateAndTimeActual</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dintExpected</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dintActual</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dwordExpected</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>dwordActual</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>intExpected</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>intActual</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>lintExpected</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>lintActual</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>lrealExpected</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>lrealActual</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ltimeExpected</Name>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ltimeActual</Name>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>lwordExpected</Name>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>lwordActual</Name>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>realExpected</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>realActual</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>sintExpected</Name>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>sintActual</Name>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>stringExpected</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>stringActual</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>wstringExpected</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Local>
+        <Local>
+          <Name>wstringActual</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Local>
+        <Local>
+          <Name>timeExpected</Name>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>timeActual</Name>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>timeOfDayExpected</Name>
+          <Type>TIME_OF_DAY</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>timeOfDayActual</Name>
+          <Type>TIME_OF_DAY</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>udintExpected</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>udintActual</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>uintExpected</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>uintActual</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>ulintExpected</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ulintActual</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>usintExpected</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>usintActual</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>wordExpected</Name>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>wordActual</Name>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DataTypesNotEquals</Name>
+          <Comment> The data type of the two ANY input parameters are not equal</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataSizeNotEquals</Name>
+          <Comment> The data size of the two ANY input parameters are not equal</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataContentNotEquals</Name>
+          <Comment> The data content of the two ANY input parameters are not equal</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>AssertEquals_TIME_OF_DAY</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> TIME_OF_DAY expected value</Comment>
+          <Type>TIME_OF_DAY</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> TIME_OF_DAY actual value</Comment>
+          <Type>TIME_OF_DAY</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_DINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LREAL expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LREAL actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_WSTRING</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> WSTRING expected value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> WSTRING actual value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_INT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> INT expected value</Comment>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> INT actual value</Comment>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DATE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DATE expected value</Comment>
+          <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DATE actual value</Comment>
+          <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_REAL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> REAL expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> REAL actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UDINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UDINT expected value</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UDINT actual value</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_SINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> SINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">SINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> SINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">SINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_TIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> TIME expected value</Comment>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> TIME actual value</Comment>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DATE_AND_TIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DATE_AND_TIME expected value</Comment>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DATE_AND_TIME actual value</Comment>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="lcls_twincat_motion.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UDINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_INT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> INT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">INT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> INT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">INT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertFalse</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetNumberOfFailedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>FailedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LWORD</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LWORD array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LWORD array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedLWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualLWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetTestByPosition</Name>
+        <ReturnType Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_Test</ReturnType>
+        <ReturnBitSize>4224</ReturnBitSize>
+        <Parameter>
+          <Name>Position</Name>
+          <Type>UINT (1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> BOOL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BOOL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> BOOL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BOOL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddTest</Name>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>ErrorMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FunctionCallResult</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>CycleCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>TestWithThisNameAlreadyExists</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerCasedTestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TrimmedTestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>IgnoreCurrentTestCase</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DWORD array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DWORD array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>FindTestSuiteInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSkippedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>SkippedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSuccessfulTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>call_after_init</Name>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AdsLogStringMessage</Name>
+      <BitSize>4128</BitSize>
+      <SubItem>
+        <Name>MsgCtrlMask</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MsgFmtStr</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StrArg</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>pack_mode</Name>
+          <Value>1</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_Utilities">FB_MemRingBuffer</Name>
+      <Comment> 	This function block implements ring buffer fifo functionality.
+	A_AddTail adds new entry, 
+	A_GetHead gets first (oldest) entry
+	A_RemoveHead gets and removes first (oldest) entry. Use A_Reset to clear all fifo data. </Comment>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>pWrite</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <Comment> Pointer to write data </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbWrite</Name>
+        <Type>UDINT</Type>
+        <Comment> Byte size of write data </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pRead</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <Comment> Pointer to read data buffer </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbRead</Name>
+        <Type>UDINT</Type>
+        <Comment> Byte size of read data buffer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pBuffer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <Comment> Pointer to ring buffer data bytes </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbBuffer</Name>
+        <Type>UDINT</Type>
+        <Comment> Max. ring buffer byte size </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOk</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE = new entry added or removed succesfully, FALSE = fifo overflow or fifo empty </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of fifo entries </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Current byte length of fifo data </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbReturn</Name>
+        <Type>UDINT</Type>
+        <Comment> If bOk == TRUE =&gt; Number of recend realy returned (removed or get) data bytes
+									   If bOk == FALSE and cbReturn &lt;&gt; 0 =&gt; Number of required read buffer data bytes (cbRead underflow) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>idxLast</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>idxFirst</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>idxGet</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pTmp</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbTmp</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbCopied</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>736</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
+        <Name>A_AddTail</Name>
+      </Action>
+      <Action>
+        <Name>A_RemoveHead</Name>
+      </Action>
+      <Action>
+        <Name>A_GetHead</Name>
+      </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">TON</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>IN</Name>
+        <Type>BOOL</Type>
+        <Comment> starts timer with rising edge, resets timer with falling edge </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PT</Name>
+        <Type>TIME</Type>
+        <Comment> time to pass, before Q is set </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> gets TRUE, delay time (PT) after a rising edge at IN </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ET</Name>
+        <Type>TIME</Type>
+        <Comment> elapsed time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StartTime</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
+      <Comment> This function block is responsible for making sure that the ADSLOGSTR-messages to the ADS-router are transmitted
+   cyclically and not in a burst. The reason this is necessary is because that if too many messages are sent at the
+   same time some get lost and are never printed to the error list output
+</Comment>
+      <BitSize>8321152</BitSize>
+      <SubItem>
+        <Name>ArrayBuffer</Name>
+        <Type>BYTE</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>1040000</Elements>
+        </ArrayInfo>
+        <BitSize>8320000</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MemRingBuffer</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_Utilities">FB_MemRingBuffer</Type>
+        <BitSize>768</BitSize>
+        <BitOffs>8320064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TimerBetweenMessages</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>8320832</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.IN</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.PT</Name>
+            <Value>10</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>MEM_RING_BUFFER_INTERNAL_USE_PER_DATA_RECORD</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8321088</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TIME_BETWEEN_MESSAGES</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>8321120</BitOffs>
+        <Default>
+          <Value>10</Value>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetLogCount</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>WriteLog</Name>
+        <Parameter>
+          <Name>MsgCtrlMask</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>MsgFmtStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>StrArg</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer overflow</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_motion.LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.PMPS">PE_Ranges</Name>
+      <Comment> Does nothing other than set the gvl for photon energy bitmask to one of two constants, K or L.
+ Workaround for compile defines not fully working for libraries at the time of writing this.
+ Otherwise I would have just used the compile define in the GVL declaration.</Comment>
+      <BitSize>64</BitSize>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Name>
+      <Comment> | Provides the functionality to create a JSON document.
+ | Steps of documentation creation:
+ | 1. StartObject() to start a new object in the document.
+ | 2. Add several keys/values via AddKeyString() and the other methods.
+ | 3. EndObject() to finish object.
+ | 4. GetDocument() in order to get the full document as string.
+ | 5. ResetDocument() if a new document should be created with the same SaxWriter instance.</Comment>
+      <BitSize>384</BitSize>
+      <SubItem>
+        <Name>initStatus</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>-1743714536</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipWriter</Name>
+        <Type GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ipWriter2</Name>
+        <Type GUID="{472183F9-5D09-4D8C-92FD-E0524EF658BF}">ITcJsonSaxWriter2</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CLSID_TcJsonSaxWriter</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000024}">CLSID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.Data1</Name>
+            <Value>3870298264</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data2</Name>
+            <Value>56256</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data3</Name>
+            <Value>17669</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[0]</Name>
+            <Value>158</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[1]</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[2]</Name>
+            <Value>93</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[3]</Name>
+            <Value>248</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[4]</Name>
+            <Value>70</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[5]</Name>
+            <Value>150</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[6]</Name>
+            <Value>7</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[7]</Name>
+            <Value>196</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>AddKeyNumber</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddString</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyFileTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsComplete</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AddUdint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLreal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKey</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ResetDocument</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyLreal</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddKeyDcTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDateTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>decimalPlaces</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__get_ipWriter</Name>
+        <ReturnType GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>_ipWriter</Name>
+          <Type GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>AddKeyBool</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddDint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyString</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBase64</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EndArray</Name>
+      </Method>
+      <Method>
+        <Name>EndObject</Name>
+      </Method>
+      <Method>
+        <Name>StartArray</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">_ST_NCADS_IDXOFFS_AxisParameter</Name>
@@ -1928,6 +14504,7 @@
       <SubItem>
         <Name>CREATETAB</Name>
         <Type>UDINT</Type>
+        <Comment> create table</Comment>
         <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
@@ -1937,6 +14514,7 @@
       <SubItem>
         <Name>CREATEMOTIONTAB</Name>
         <Type>UDINT</Type>
+        <Comment> create motion function table</Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Default>
@@ -1946,6 +14524,7 @@
       <SubItem>
         <Name>DELETETAB</Name>
         <Type>UDINT</Type>
+        <Comment> delete tables </Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -1954,7 +14533,7 @@
       </SubItem>
       <Properties>
         <Property>
-          <Name>hide</Name>
+          <Name>conditionalshow</Name>
         </Property>
       </Properties>
     </DataType>
@@ -2133,6 +14712,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2145,10 +14749,12 @@
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">_TCMCGLOBAL</Name>
+      <Comment>	Global constants and parameters </Comment>
       <BitSize>7104</BitSize>
       <SubItem>
         <Name>NCPORT_TCMC</Name>
         <Type>UINT</Type>
+        <Comment> 20110511 type changed from INT to UINT </Comment>
         <BitSize>16</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -2164,6 +14770,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_COUPLING</Name>
         <Type>UINT</Type>
+        <Comment> 20110511 type changed from INT to UINT </Comment>
         <BitSize>16</BitSize>
         <BitOffs>80</BitOffs>
         <Default>
@@ -2194,6 +14801,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_CAM</Name>
         <Type>UINT</Type>
+        <Comment> 20110511 type changed from INT to UINT </Comment>
         <BitSize>16</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
@@ -2209,6 +14817,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_CAM_FAST</Name>
         <Type>UINT</Type>
+        <Comment> 20150728 KSt added </Comment>
         <BitSize>16</BitSize>
         <BitOffs>304</BitOffs>
         <Default>
@@ -2239,6 +14848,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_SUPERPOSITION</Name>
         <Type>UINT</Type>
+        <Comment> 20140930 KSt added </Comment>
         <BitSize>16</BitSize>
         <BitOffs>512</BitOffs>
         <Default>
@@ -2314,6 +14924,7 @@
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_NCADS_Axis</Type>
+        <Comment> IDXGRP and IDXOFFS constants of axis parameter/status/functions </Comment>
         <BitSize>4320</BitSize>
         <BitOffs>832</BitOffs>
         <Properties>
@@ -2330,6 +14941,7 @@
       <SubItem>
         <Name>Table</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_NCADS_Table</Type>
+        <Comment> IDXGRP and IDXOFFS constants of table parameter/status/functions </Comment>
         <BitSize>352</BitSize>
         <BitOffs>5152</BitOffs>
         <Properties>
@@ -2409,13 +15021,38 @@
       <Action>
         <Name>ReadDeviceInfo</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
         <Property>
-          <Name>hide</Name>
+          <Name>conditionalshow</Name>
         </Property>
       </Properties>
     </DataType>
@@ -2598,7 +15235,7 @@
       </Relations>
     </DataType>
     <DataType>
-      <Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+      <Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
       <BitSize>32</BitSize>
       <SubItem>
         <Name>Operational</Name>
@@ -2709,6 +15346,12 @@
         <BitOffs>17</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>IsDriveLimitActive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>18</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>ContinuousMotion</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
         <BitSize>1</BitSize>
@@ -2795,6 +15438,11 @@
       <Format Name="IEC">
         <Printf>16#%08X</Printf>
       </Format>
+      <Relations>
+        <Relation Priority="100">
+          <Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+        </Relation>
+      </Relations>
     </DataType>
     <DataType>
       <Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
@@ -2990,11 +15638,11 @@
       </ArrayInfo>
     </DataType>
     <DataType>
-      <Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+      <Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>StateDWord</Name>
-        <Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+        <Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
         <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -3243,6 +15891,18 @@ External Setpoint Generation:
         <BitOffs>1600</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>AbsPhasingPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TorqueOffset</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>ActPosWithoutPosCorrection</Name>
         <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
         <BitSize>64</BitSize>
@@ -3287,6 +15947,9 @@ External Setpoint Generation:
         </Relation>
         <Relation Priority="100">
           <Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
         </Relation>
       </Relations>
     </DataType>
@@ -3837,24 +16500,6 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-      <BitSize>48</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-      <ArrayInfo>
-        <LBound>0</LBound>
-        <Elements>6</Elements>
-      </ArrayInfo>
-      <Format>
-        <Printf>%d.%d.%d.%d.%d.%d</Printf>
-        <Parameter>[0]</Parameter>
-        <Parameter>[1]</Parameter>
-        <Parameter>[2]</Parameter>
-        <Parameter>[3]</Parameter>
-        <Parameter>[4]</Parameter>
-        <Parameter>[5]</Parameter>
-      </Format>
-    </DataType>
-    <DataType>
       <Name Namespace="Tc2_System">T_AmsNetIdArr</Name>
       <Comment> TwinCAT AMS netID address bytes. </Comment>
       <BitSize>48</BitSize>
@@ -4276,8 +16921,25 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_MC2">_E_PhasingState</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>PhasingInactive</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhasingActivated</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhasingAborted</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">_InternalAxisRefData</Name>
-      <BitSize>96</BitSize>
+      <BitSize>128</BitSize>
       <SubItem>
         <Name>NcCycleCounterAvailable</Name>
         <Type>BOOL</Type>
@@ -4305,6 +16967,13 @@ External Setpoint Generation:
         <Comment> counter increments to max 100 if the task index for the status update never changes </Comment>
         <BitSize>16</BitSize>
         <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PhasingState</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_MC2">_E_PhasingState</Type>
+        <Comment> KSt 20190703 global handshake for phasing blocks</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -4343,7 +17012,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>NcToPlc</Name>
-        <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</Type>
+        <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</Type>
         <BitSize>2048</BitSize>
         <BitOffs>1088</BitOffs>
         <Properties>
@@ -4396,7 +17065,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>_internal</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_InternalAxisRefData</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>4800</BitOffs>
         <Properties>
           <Property>
@@ -4412,7 +17081,7 @@ External Setpoint Generation:
           <Elements>128</Elements>
         </ArrayInfo>
         <BitSize>4096</BitSize>
-        <BitOffs>4896</BitOffs>
+        <BitOffs>4928</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -4422,6 +17091,31 @@ External Setpoint Generation:
       <Action>
         <Name>ReadStatus</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -4506,6 +17200,570 @@ External Setpoint Generation:
         <Enum>-1</Enum>
         <Comment> Do not home, ever</Comment>
       </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_MC2">ST_AxisParameterSet</Name>
+      <BitSize>8192</BitSize>
+      <SubItem>
+        <Name>AxisId</Name>
+        <Type>DWORD</Type>
+        <Comment> TC3 &amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp; </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nAxisType</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00000003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sAxisName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00000002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAxisCycleTime</Name>
+        <Type>LREAL</Type>
+        <Comment> available from Tc 2.11 R2 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionAreaControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0000000F </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPositionAreaControlRange</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000010 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotionControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000011 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fMotionControlTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000012 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableLoop</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000013 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLoopDistance</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000014 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableTargetPosControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000015 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTargetPosControlRange</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000016 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTargetPosControlTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000017 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloMaximum</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000027 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRefVeloSearch</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000006 calibration velo (TO plc cam)		(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRefVeloSync</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000007 calibration velo (off plc cam)	(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloSlowManual</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000008 manual velocity (slow)			(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloFastManual</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000009 manual velocity (fast)			(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fMotionControlRange</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000028 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePEHTimeControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000029 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPEHControlTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0000002A </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBacklashCompensation</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0000002B </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fBacklash</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0000002C </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sAmsNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> 0x00000031 (Wandlung von "BYTE b[6]" zum nullterminierten STRING mit 23+1 Zeichen) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPort</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000031 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nChnNo</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000031 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAcceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000101 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDeceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000102 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fJerk</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000103 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncId</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010001 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncType</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sEncName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00010002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScaleFactorNumerator</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010023 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScaleFactorDenominator</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010024 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScaleFactorInternal</Name>
+        <Type>LREAL</Type>
+        <Comment> fEncScaleFactorInternal = fEncScaleFactorNumerator / fEncScaleFactorDenominator </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncOffset</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010007 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncIsInverse</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00010008 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncModuloFactor</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010009 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncMode</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x0001000A </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncEnableSoftEndMinControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0001000B </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2784</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncEnableSoftEndMaxControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0001000C </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncSoftEndMin</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0001000D </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncSoftEndMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0001000E </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncMaxIncrement</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010015 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncRefSoftSyncMask</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010108 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncEnablePosCorrection</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00010016 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncReferenceSystem</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010019	(15.10.15: parameter extension) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3040</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncPosCorrectionFilterTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010017 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncRefSearchInverse</Name>
+        <Type>UINT</Type>
+        <Comment> 0x00010101 	(17.05.11: parameter extension) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3136</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncRefSyncInverse</Name>
+        <Type>UINT</Type>
+        <Comment> 0x00010102 	(17.05.11: parameter extension) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncRefMode</Name>
+        <Type>UDINT</Type>
+        <Comment> 0x00010107 	(17.05.11: parameter extension) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncRefPosition</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010103 	(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlId</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00020001 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlType</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00020003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCtrlName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00020002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>3328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCtrlEnablePosDiffControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00020010 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCtrlEnableVeloDiffControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00020011 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosDiffMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020012 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosDiffMaxTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020013 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosKp</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020102 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3776</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosTn</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020103 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3840</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosTv</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020104 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosTd</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020105 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosExtKp</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020106 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosExtVelo</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020107 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlAccKa</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020108 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDriveId</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00030001 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDriveType</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00030003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sDriveName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00030002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>4288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDriveIsInverse</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00030006 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>4544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDriveControlDWord</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00030010 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveVeloReferenz</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030101 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveOutputReferenz</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030102 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveOutputScalingAcc</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0003000A	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveOutputScalingTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0003000B	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveInputScalingTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030031	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4864</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveInputFiltertimeTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030032	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveInputFiltertimeTorqueDerivative</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030033	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAccelerationMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x000000F1	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>5056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDecelerationMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x000000F2	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>5120</BitOffs>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Name>
@@ -4654,7 +17912,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
-      <BitSize>11264</BitSize>
+      <BitSize>21056</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">AXIS_REF</Type>
@@ -4779,12 +18037,51 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>nRawEncoderULINT</Name>
+        <Type>ULINT</Type>
+        <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>9088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRawEncoderUINT</Name>
+        <Type>UINT</Type>
+        <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRawEncoderINT</Name>
+        <Type>INT</Type>
+        <Comment> Raw encoder IO for INT (LVDT)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>bAllForwardEnable</Name>
         <Type>BOOL</Type>
         <Comment> Psuedo-hardware 
  Forward enable EPS summary</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9064</BitOffs>
+        <BitOffs>9184</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4806,7 +18103,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Backward enable EPS summary</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9072</BitOffs>
+        <BitOffs>9192</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4828,7 +18125,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Enable EPS summary encapsulating emergency stop button and any additional motion preventive hardware</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9080</BitOffs>
+        <BitOffs>9200</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4850,7 +18147,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Forward virtual gantry limit switch</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9088</BitOffs>
+        <BitOffs>9208</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4872,7 +18169,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Backward virtual gantry limit switch</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9096</BitOffs>
+        <BitOffs>9216</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4890,12 +18187,46 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Encoder count summary, if linked above</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>9248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nEncoderCount
+        io: i
+        field: DESC Count from encoder hardware
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Settings 
+ Name to use for log messages, fast faults, etc.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>9280</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:sName
+        io: i
+        field: DESC PLC program name
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>bPowerSelf</Name>
         <Type>BOOL</Type>
-        <Comment> Settings 
- If TRUE, we want to enable the motor independently of PMPS or other safety systems.</Comment>
+        <Comment> If TRUE, we want to enable the motor independently of PMPS or other safety systems.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9104</BitOffs>
+        <BitOffs>9928</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4917,7 +18248,7 @@ External Setpoint Generation:
         <Type Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Type>
         <Comment> Determines when we automatically enable the motor</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9120</BitOffs>
+        <BitOffs>9936</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -4937,7 +18268,7 @@ External Setpoint Generation:
         <Type Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Type>
         <Comment> Determines when we automatically disengage the brake</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9136</BitOffs>
+        <BitOffs>9952</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4957,7 +18288,7 @@ External Setpoint Generation:
         <Type Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Type>
         <Comment> Determines our encoder homing strategy</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9152</BitOffs>
+        <BitOffs>9968</BitOffs>
         <Default>
           <Value>-1</Value>
         </Default>
@@ -4977,7 +18308,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Set true to activate gantry EPS</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9168</BitOffs>
+        <BitOffs>9984</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4999,7 +18330,7 @@ External Setpoint Generation:
         <Type>LINT</Type>
         <Comment> Set to gantry difference tolerance</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9216</BitOffs>
+        <BitOffs>10048</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -5009,7 +18340,7 @@ External Setpoint Generation:
         <Type>ULINT</Type>
         <Comment> Encoder count at which this axis is aligned with other axis</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9280</BitOffs>
+        <BitOffs>10112</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -5020,7 +18351,7 @@ External Setpoint Generation:
         <Comment> Commands 
  Used internally to request enables</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9344</BitOffs>
+        <BitOffs>10176</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5039,7 +18370,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Used internally to reset errors and other state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9352</BitOffs>
+        <BitOffs>10184</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5058,7 +18389,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Used internally and by the IOC to start or stop a move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9360</BitOffs>
+        <BitOffs>10192</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5078,7 +18409,7 @@ External Setpoint Generation:
         <Comment> Command Args 
  Used internally and by the IOC to pick what kind of move to do</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9376</BitOffs>
+        <BitOffs>10208</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5095,7 +18426,7 @@ External Setpoint Generation:
         <Type>INT</Type>
         <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9392</BitOffs>
+        <BitOffs>10224</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5112,7 +18443,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9408</BitOffs>
+        <BitOffs>10240</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5129,7 +18460,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move velocity</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9472</BitOffs>
+        <BitOffs>10304</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5146,7 +18477,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9536</BitOffs>
+        <BitOffs>10368</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5163,7 +18494,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9600</BitOffs>
+        <BitOffs>10432</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5180,7 +18511,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a home position</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9664</BitOffs>
+        <BitOffs>10496</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5198,7 +18529,7 @@ External Setpoint Generation:
         <Comment> Info 
  Unique ID assigned to each axis in the NC</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>9728</BitOffs>
+        <BitOffs>10560</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -5219,7 +18550,7 @@ External Setpoint Generation:
         <Comment> Returns 
  TRUE if done enabling</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9760</BitOffs>
+        <BitOffs>10592</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5238,7 +18569,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> TRUE if in the middle of a command</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9768</BitOffs>
+        <BitOffs>10600</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5257,7 +18588,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> TRUE if we've done a command and it has finished</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9776</BitOffs>
+        <BitOffs>10608</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5272,11 +18603,30 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>bSafetyReady</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have safety permission to move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10616</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bSafetyReady
+        io: i
+        field: ONAM FALSE
+        field: ZNAM TRUE
+        field: DESC TRUE if safe to start a move
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <Comment> TRUE if we're in an error state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9784</BitOffs>
+        <BitOffs>10624</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5294,7 +18644,7 @@ External Setpoint Generation:
         <Type>UDINT</Type>
         <Comment> Error code if nonzero</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>9792</BitOffs>
+        <BitOffs>10656</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5311,7 +18661,7 @@ External Setpoint Generation:
         <Type>STRING(80)</Type>
         <Comment> Message to identify the error state</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>9824</BitOffs>
+        <BitOffs>10688</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5324,11 +18674,32 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>sCustomErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Internal hook for custom error messages</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>11336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stAxisParameters</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_AxisParameterSet</Type>
+        <Comment> MC_ReadParameterSet Output</Comment>
+        <BitSize>8192</BitSize>
+        <BitOffs>12032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAxisParamsInit</Name>
+        <Type>BOOL</Type>
+        <Comment> True if we've updated stAxisParameters at least once</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>20224</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>stAxisStatus</Name>
         <Type Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Type>
         <Comment> Misc axis status information for the IOC</Comment>
         <BitSize>768</BitSize>
-        <BitOffs>10496</BitOffs>
+        <BitOffs>20288</BitOffs>
       </SubItem>
     </DataType>
     <DataType>
@@ -5405,59 +18776,6 @@ External Setpoint Generation:
       <Properties>
         <Property>
           <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">R_TRIG</Name>
-      <Comment>
-	Rising Edge detection.
-</Comment>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> Signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
     </DataType>
@@ -5570,7 +18888,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1792</BitOffs>
         <Properties>
           <Property>
@@ -5578,6 +18896,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -5619,86 +18962,12 @@ External Setpoint Generation:
       <BitSize>0</BitSize>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_Standard">TON</Name>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>IN</Name>
-        <Type>BOOL</Type>
-        <Comment> starts timer with rising edge, resets timer with falling edge </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PT</Name>
-        <Type>TIME</Type>
-        <Comment> time to pass, before Q is set </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> gets TRUE, delay time (PT) after a rising edge at IN </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ET</Name>
-        <Type>TIME</Type>
-        <Comment> elapsed time </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>StartTime</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="Tc2_Standard">TP</Name>
       <Comment>
 	Pulse Timer.
 	Q produces a High-Signal with the length of PT on every rising edge on IN.
 </Comment>
-      <BitSize>224</BitSize>
+      <BitSize>256</BitSize>
       <SubItem>
         <Name>IN</Name>
         <Type>BOOL</Type>
@@ -5757,6 +19026,31 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -5766,7 +19060,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_Power</Name>
-      <BitSize>896</BitSize>
+      <BitSize>960</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -5943,7 +19237,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>EnableOffOnDelay</Name>
         <Type Namespace="Tc2_Standard">TP</Type>
-        <BitSize>224</BitSize>
+        <BitSize>256</BitSize>
         <BitOffs>640</BitOffs>
         <Properties>
           <Property>
@@ -5955,13 +19249,38 @@ External Setpoint Generation:
         <Name>iOverride</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -5974,7 +19293,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Name>
-      <BitSize>256</BitSize>
+      <BitSize>320</BitSize>
       <SubItem>
         <Name>EnableBlendingPosition</Name>
         <Type>BOOL</Type>
@@ -6001,6 +19320,22 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>IgnorePositionMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> PositionAreaMonitoring, TargetPositionMonitoring and StopMonitoring can be ignored using this flag - 20190311 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>EnableStopPositionMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> PositionAreaMonitoring, TargetPositionMonitoring can be enabled for MC_Stop and MC_Halt commands - 20191010 
+ Monitoring can just be enabled if the monitoring parameters of the axis are enabled as well 
+ The default is no monitoring for both commands even if monitoring options are enabled by axis parameters </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">_E_TcNC_StartPosType</Name>
@@ -6009,82 +19344,102 @@ External Setpoint Generation:
       <EnumInfo>
         <Text>TCNC_START_ABSOLUTE</Text>
         <Enum>1</Enum>
+        <Comment>Start to absolute position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_RELATIVE</Text>
         <Enum>2</Enum>
+        <Comment>Start to relative position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESS_PLUS</Text>
         <Enum>3</Enum>
+        <Comment>Start to endless positive position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESS_MINUS</Text>
         <Enum>4</Enum>
+        <Comment>Start to endless negative position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO</Text>
         <Enum>5</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ADDITIVE</Text>
         <Enum>6</Enum>
+        <Comment>Start to a position relative to the last recent target position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_SHORT</Text>
         <Enum>261</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_PLUS</Text>
         <Enum>517</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_MINUS</Text>
         <Enum>773</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_CURRENT</Text>
         <Enum>1029</Enum>
+        <Comment> start to modulo position in current direction </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ABS_INTERNAL</Text>
         <Enum>9</Enum>
+        <Comment>Start to absolute position, internal use</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSPLUS_SLOWMANUAL</Text>
         <Enum>272</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSMINUS_SLOWMANUAL</Text>
         <Enum>273</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSPLUS_FASTMANUAL</Text>
         <Enum>528</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSMINUS_FASTMANUAL</Text>
         <Enum>529</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_STOPANDLOCK</Text>
         <Enum>4096</Enum>
+        <Comment> stop axis and lock against any motion commands </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_HALT</Text>
         <Enum>8192</Enum>
+        <Comment> halt axis - can be interrupted by any motion commands </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_TORQUE_ABORT</Text>
         <Enum>12288</Enum>
+        <Comment> 20181210 Fap - halt torque control </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_TORQUE_ABSOLUTE</Text>
         <Enum>12289</Enum>
+        <Comment> 20181210 Fap - Start torque control absolute </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_TORQUE_RELATIVE</Text>
         <Enum>12290</Enum>
+        <Comment> 20190108 Fap - Start torque control relative NOT IMPLEMENTED </Comment>
       </EnumInfo>
     </DataType>
     <DataType>
@@ -6392,6 +19747,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6399,69 +19779,6 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>hide_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
     </DataType>
@@ -6543,10 +19860,11 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Name>
-      <BitSize>7296</BitSize>
+      <BitSize>7488</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -6583,6 +19901,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_E_TcNC_StartPosType</Type>
+        <Comment> 20110511 KSt type changed for Tc3 </Comment>
         <BitSize>16</BitSize>
         <BitOffs>208</BitOffs>
         <Properties>
@@ -6655,6 +19974,8 @@ External Setpoint Generation:
       <SubItem>
         <Name>BufferMode</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_BufferMode</Type>
+        <Comment>	Direction			:	MC_Direction := MC_Positive_Direction;	
+ E </Comment>
         <BitSize>16</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
@@ -6667,7 +19988,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>640</BitOffs>
         <Properties>
           <Property>
@@ -6679,8 +20000,9 @@ External Setpoint Generation:
       <SubItem>
         <Name>Reset</Name>
         <Type>BOOL</Type>
+        <Comment> for internal use only </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6691,8 +20013,9 @@ External Setpoint Generation:
       <SubItem>
         <Name>GotoRunState</Name>
         <Type>BOOL</Type>
+        <Comment> for internal use only </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>904</BitOffs>
+        <BitOffs>968</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6703,8 +20026,9 @@ External Setpoint Generation:
       <SubItem>
         <Name>Done</Name>
         <Type>BOOL</Type>
+        <Comment> Same meaning as InVelocity for continous motion commands </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>912</BitOffs>
+        <BitOffs>976</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6716,7 +20040,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>920</BitOffs>
+        <BitOffs>984</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6728,7 +20052,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6740,7 +20064,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
+        <BitOffs>1000</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6752,7 +20076,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>944</BitOffs>
+        <BitOffs>1008</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6764,7 +20088,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>960</BitOffs>
+        <BitOffs>1024</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6780,7 +20104,7 @@ External Setpoint Generation:
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>992</BitOffs>
+        <BitOffs>1056</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6792,7 +20116,7 @@ External Setpoint Generation:
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1008</BitOffs>
+        <BitOffs>1072</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -6804,7 +20128,7 @@ External Setpoint Generation:
         <Name>iState</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_E_TcMC_STATES</Type>
         <BitSize>16</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
         <Default>
           <Value>100</Value>
         </Default>
@@ -6813,175 +20137,187 @@ External Setpoint Generation:
         <Name>sStartRequest</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_TcNC_UnversalAxisStartRequest</Type>
         <BitSize>640</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sStartResponse</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_TcNC_UnversalAxisStartResponse</Type>
         <BitSize>32</BitSize>
-        <BitOffs>1728</BitOffs>
+        <BitOffs>1792</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbAdsReadWrite</Name>
         <Type Namespace="Tc2_System">ADSRDWRTEX</Type>
         <BitSize>1792</BitSize>
-        <BitOffs>1792</BitOffs>
+        <BitOffs>1856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ContinousMode</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3584</BitOffs>
+        <BitOffs>3648</BitOffs>
       </SubItem>
       <SubItem>
         <Name>InVelocity</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3592</BitOffs>
+        <BitOffs>3656</BitOffs>
       </SubItem>
       <SubItem>
         <Name>DiffCycleCounter</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3616</BitOffs>
+        <BitOffs>3680</BitOffs>
       </SubItem>
       <SubItem>
         <Name>EmptyStartResponse</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_TcNC_UnversalAxisStartResponse</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3648</BitOffs>
+        <BitOffs>3712</BitOffs>
       </SubItem>
       <SubItem>
         <Name>COUNT_R</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3680</BitOffs>
+        <BitOffs>3744</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CounterCmdNoZero</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3712</BitOffs>
+        <BitOffs>3776</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CounterCmdNotStarted</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3720</BitOffs>
+        <BitOffs>3784</BitOffs>
       </SubItem>
       <SubItem>
         <Name>DiffCmdNo</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>3728</BitOffs>
+        <BitOffs>3792</BitOffs>
       </SubItem>
       <SubItem>
         <Name>InitialNcToPlcCmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>3744</BitOffs>
+        <BitOffs>3808</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCycleCounter</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3760</BitOffs>
+        <BitOffs>3824</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastNcCycleCounter</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3768</BitOffs>
+        <BitOffs>3832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcMappingCounter</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3776</BitOffs>
+        <BitOffs>3840</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCycleCounterAvailable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3784</BitOffs>
+        <BitOffs>3848</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCycleCounterNotAvailable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3792</BitOffs>
+        <BitOffs>3856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCyclicFeedbackExpected</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3800</BitOffs>
+        <BitOffs>3864</BitOffs>
       </SubItem>
       <SubItem>
         <Name>PlcDebugCode</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3808</BitOffs>
+        <BitOffs>3872</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AxisIsSlave</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3840</BitOffs>
+        <BitOffs>3904</BitOffs>
       </SubItem>
       <SubItem>
         <Name>GetTaskIndex</Name>
         <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
         <BitSize>256</BitSize>
-        <BitOffs>3904</BitOffs>
+        <BitOffs>3968</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CycleCounter</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4160</BitOffs>
+        <BitOffs>4224</BitOffs>
       </SubItem>
       <SubItem>
         <Name>BusyCounter</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4192</BitOffs>
+        <BitOffs>4256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTimeOut</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4224</BitOffs>
+        <BitOffs>4288</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbStopMonitoringTimeOut</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4480</BitOffs>
+        <BitOffs>4544</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTimeOutMappingCounter</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4736</BitOffs>
+        <BitOffs>4800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>4992</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>5056</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sTempMsg</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>5088</BitOffs>
+        <BitOffs>5184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AccDecreasing</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>7232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AccOld</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>7296</BitOffs>
       </SubItem>
       <SubItem>
         <Name>OpMode</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_TcNc_OperationModes</Type>
         <BitSize>128</BitSize>
-        <BitOffs>7136</BitOffs>
+        <BitOffs>7360</BitOffs>
         <Properties>
           <Property>
             <Name>suppress_warning_0</Name>
@@ -7007,19 +20343,44 @@ External Setpoint Generation:
       <Action>
         <Name>ActCalcDiffCmdNo</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
         <Property>
-          <Name>hide</Name>
+          <Name>conditionalshow</Name>
         </Property>
       </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_Halt</Name>
-      <BitSize>8256</BitSize>
+      <BitSize>8512</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -7085,7 +20446,7 @@ External Setpoint Generation:
         <Name>Options</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Type>
         <Comment> optional parameters </Comment>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>384</BitOffs>
         <Properties>
           <Property>
@@ -7098,7 +20459,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>640</BitOffs>
+        <BitOffs>704</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7110,7 +20471,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>648</BitOffs>
+        <BitOffs>712</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7122,7 +20483,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>656</BitOffs>
+        <BitOffs>720</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7134,7 +20495,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>664</BitOffs>
+        <BitOffs>728</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7146,7 +20507,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>672</BitOffs>
+        <BitOffs>736</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7158,7 +20519,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>704</BitOffs>
+        <BitOffs>768</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7174,26 +20535,51 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>736</BitOffs>
+        <BitOffs>800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitSize>7488</BitSize>
+        <BitOffs>960</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8192</BitOffs>
+        <BitOffs>8448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -7258,7 +20644,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveVelocity</Name>
-      <BitSize>8384</BitSize>
+      <BitSize>8640</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -7364,7 +20750,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>512</BitOffs>
         <Properties>
           <Property>
@@ -7378,7 +20764,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Commanded velocity reached </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>768</BitOffs>
+        <BitOffs>832</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7390,7 +20776,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>776</BitOffs>
+        <BitOffs>840</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7402,7 +20788,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>784</BitOffs>
+        <BitOffs>848</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7414,7 +20800,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>792</BitOffs>
+        <BitOffs>856</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7426,7 +20812,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>800</BitOffs>
+        <BitOffs>864</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7438,7 +20824,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7454,26 +20840,51 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>960</BitOffs>
+        <BitOffs>1024</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitSize>7488</BitSize>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8320</BitOffs>
+        <BitOffs>8576</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -7523,7 +20934,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveAbsolute</Name>
-      <BitSize>8448</BitSize>
+      <BitSize>8704</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -7633,7 +21044,7 @@ External Setpoint Generation:
         <Name>Options</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Type>
         <Comment> optional parameters </Comment>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -7646,7 +21057,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7658,7 +21069,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
+        <BitOffs>904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7670,7 +21081,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7682,7 +21093,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7694,7 +21105,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7706,7 +21117,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7722,26 +21133,51 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitSize>7488</BitSize>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8384</BitOffs>
+        <BitOffs>8640</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -7751,7 +21187,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveRelative</Name>
-      <BitSize>8448</BitSize>
+      <BitSize>8704</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -7854,7 +21290,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -7867,7 +21303,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7879,7 +21315,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
+        <BitOffs>904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7891,7 +21327,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7903,7 +21339,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7915,7 +21351,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7927,7 +21363,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -7943,26 +21379,51 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitSize>7488</BitSize>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8384</BitOffs>
+        <BitOffs>8640</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -7972,7 +21433,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_Jog</Name>
-      <BitSize>42496</BitSize>
+      <BitSize>43712</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -8185,122 +21646,122 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveVelocity</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>8384</BitSize>
+        <BitSize>8640</BitSize>
         <BitOffs>768</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveVelocityOut</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>9152</BitOffs>
+        <BitOffs>9408</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Direction</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_Direction</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9248</BitOffs>
+        <BitOffs>9504</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteHalt</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>9264</BitOffs>
+        <BitOffs>9520</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Halt</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_Halt</Type>
-        <BitSize>8256</BitSize>
-        <BitOffs>9280</BitOffs>
+        <BitSize>8512</BitSize>
+        <BitOffs>9536</BitOffs>
       </SubItem>
       <SubItem>
         <Name>HaltOut</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>17536</BitOffs>
+        <BitOffs>18048</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteMoveAbsolute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>17632</BitOffs>
+        <BitOffs>18144</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveAbsolute</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveAbsolute</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>17664</BitOffs>
+        <BitSize>8704</BitSize>
+        <BitOffs>18176</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveAbsoluteOut</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>26112</BitOffs>
+        <BitOffs>26880</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteMoveRelative</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>26208</BitOffs>
+        <BitOffs>26976</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveRelative</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveRelative</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>26240</BitOffs>
+        <BitSize>8704</BitSize>
+        <BitOffs>27008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveRelativeOut</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>34688</BitOffs>
+        <BitOffs>35712</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogMove</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>34816</BitOffs>
+        <BitSize>7488</BitSize>
+        <BitOffs>35840</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastJogMoveResult</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>42112</BitOffs>
+        <BitOffs>43328</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteJogMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>42208</BitOffs>
+        <BitOffs>43424</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_E_TcNC_StartPosType</Type>
         <BitSize>16</BitSize>
-        <BitOffs>42224</BitOffs>
+        <BitOffs>43440</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogMoveOut</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>42240</BitOffs>
+        <BitOffs>43456</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogEnd</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>42336</BitOffs>
+        <BitOffs>43552</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TargetPosition</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>42368</BitOffs>
+        <BitOffs>43584</BitOffs>
       </SubItem>
       <SubItem>
         <Name>modulo</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>42432</BitOffs>
+        <BitOffs>43648</BitOffs>
       </SubItem>
       <Action>
         <Name>ActJogMove</Name>
@@ -8308,6 +21769,31 @@ External Setpoint Generation:
       <Action>
         <Name>ActCheckJogEnd</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -8317,7 +21803,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveModulo</Name>
-      <BitSize>8576</BitSize>
+      <BitSize>8832</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -8432,7 +21918,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -8445,7 +21931,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -8457,7 +21943,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
+        <BitOffs>904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -8469,7 +21955,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -8481,7 +21967,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -8493,7 +21979,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -8505,7 +21991,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -8521,41 +22007,66 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitSize>7488</BitSize>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">_E_TcNC_StartPosType</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8384</BitOffs>
+        <BitOffs>8640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8400</BitOffs>
+        <BitOffs>8656</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TriggerExecute</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>8448</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>8704</BitOffs>
       </SubItem>
       <Action>
         <Name>MC_MoveModuloCall</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -8854,6 +22365,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -9014,6 +22550,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -9250,7 +22811,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>2112</BitOffs>
         <Properties>
           <Property>
@@ -9258,6 +22819,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -9605,7 +23191,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>7680</BitOffs>
         <Properties>
           <Property>
@@ -9624,6 +23210,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -9758,6 +23369,31 @@ External Setpoint Generation:
         <BitSize>1344</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -9889,6 +23525,31 @@ External Setpoint Generation:
         <BitSize>1344</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -10034,7 +23695,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
       <SubItem>
@@ -10049,6 +23710,31 @@ External Setpoint Generation:
         <BitSize>1792</BitSize>
         <BitOffs>2304</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -10295,9 +23981,34 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbRTrigg</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>17920</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -10446,6 +24157,31 @@ External Setpoint Generation:
         <BitSize>8064</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -10577,6 +24313,31 @@ External Setpoint Generation:
         <BitSize>1408</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -10737,6 +24498,31 @@ External Setpoint Generation:
         <BitSize>1792</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -10888,7 +24674,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
       <SubItem>
@@ -10903,6 +24689,31 @@ External Setpoint Generation:
         <BitSize>1728</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11034,6 +24845,31 @@ External Setpoint Generation:
         <BitSize>1408</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11188,6 +25024,31 @@ External Setpoint Generation:
         <BitSize>1856</BitSize>
         <BitOffs>2240</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11197,7 +25058,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_HomePrepare</Name>
-      <BitSize>20480</BitSize>
+      <BitSize>20544</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -11406,14 +25267,14 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>20352</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecuteReadNC</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>20448</BitOffs>
+        <BitOffs>20480</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11422,7 +25283,7 @@ External Setpoint Generation:
         <Name>bExecuteWriteNC</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>20456</BitOffs>
+        <BitOffs>20488</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11431,11 +25292,36 @@ External Setpoint Generation:
         <Name>nState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>20464</BitOffs>
+        <BitOffs>20496</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11445,7 +25331,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_HomeFinish</Name>
-      <BitSize>4224</BitSize>
+      <BitSize>4288</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -11605,14 +25491,14 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>4096</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecuteWriteNC</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>4192</BitOffs>
+        <BitOffs>4224</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11621,11 +25507,36 @@ External Setpoint Generation:
         <Name>nState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>4208</BitOffs>
+        <BitOffs>4240</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11635,7 +25546,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_HomeVirtual</Name>
-      <BitSize>60288</BitSize>
+      <BitSize>60736</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -11844,32 +25755,32 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbMoveVelocity</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>8384</BitSize>
+        <BitSize>8640</BitSize>
         <BitOffs>27008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomePrepare</Name>
         <Type Namespace="lcls_twincat_motion">FB_HomePrepare</Type>
-        <BitSize>20480</BitSize>
-        <BitOffs>35392</BitOffs>
+        <BitSize>20544</BitSize>
+        <BitOffs>35648</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomeFinish</Name>
         <Type Namespace="lcls_twincat_motion">FB_HomeFinish</Type>
-        <BitSize>4224</BitSize>
-        <BitOffs>55872</BitOffs>
+        <BitSize>4288</BitSize>
+        <BitOffs>56192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>60096</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>60480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nHomingState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>60192</BitOffs>
+        <BitOffs>60608</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11878,7 +25789,7 @@ External Setpoint Generation:
         <Name>bExecuteHomeToSwitch</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60208</BitOffs>
+        <BitOffs>60624</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11887,7 +25798,7 @@ External Setpoint Generation:
         <Name>bExecuteMoveVelocity</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60216</BitOffs>
+        <BitOffs>60632</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11896,7 +25807,7 @@ External Setpoint Generation:
         <Name>bExecutePrepare</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60224</BitOffs>
+        <BitOffs>60640</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11905,7 +25816,7 @@ External Setpoint Generation:
         <Name>bExecuteFinish</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60232</BitOffs>
+        <BitOffs>60648</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -11914,20 +25825,20 @@ External Setpoint Generation:
         <Name>bExecuteHomeDirect</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60240</BitOffs>
+        <BitOffs>60656</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nCmdDataLocal</Name>
         <Type>UINT</Type>
         <Comment>Ensure that nCmdData is not changed during sequence</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>60256</BitOffs>
+        <BitOffs>60672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bSequenceReady</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60272</BitOffs>
+        <BitOffs>60688</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -11936,11 +25847,36 @@ External Setpoint Generation:
         <Name>bRestoreNCDataNeeded</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60280</BitOffs>
+        <BitOffs>60696</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12296,6 +26232,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12441,7 +26402,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1728</BitOffs>
         <Properties>
           <Property>
@@ -12460,6 +26421,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12469,7 +26455,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_DriveVirtual</Name>
-      <BitSize>167488</BitSize>
+      <BitSize>170496</BitSize>
       <SubItem>
         <Name>sVersion</Name>
         <Type>STRING(80)</Type>
@@ -12933,135 +26919,104 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbPower</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_Power</Type>
-        <BitSize>896</BitSize>
+        <BitSize>960</BitSize>
         <BitOffs>14272</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHalt</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_Halt</Type>
-        <BitSize>8256</BitSize>
-        <BitOffs>15168</BitOffs>
+        <BitSize>8512</BitSize>
+        <BitOffs>15232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbJog</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_Jog</Type>
-        <BitSize>42496</BitSize>
-        <BitOffs>23424</BitOffs>
+        <BitSize>43712</BitSize>
+        <BitOffs>23744</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveVelocity</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>8384</BitSize>
-        <BitOffs>65920</BitOffs>
+        <BitSize>8640</BitSize>
+        <BitOffs>67456</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveRelative</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveRelative</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>74304</BitOffs>
+        <BitSize>8704</BitSize>
+        <BitOffs>76096</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveAbsolute</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveAbsolute</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>82752</BitOffs>
+        <BitSize>8704</BitSize>
+        <BitOffs>84800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveModulo</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_MoveModulo</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>91200</BitOffs>
+        <BitSize>8832</BitSize>
+        <BitOffs>93504</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomeVirtual</Name>
         <Type Namespace="lcls_twincat_motion">FB_HomeVirtual</Type>
-        <BitSize>60288</BitSize>
-        <BitOffs>99776</BitOffs>
+        <BitSize>60736</BitSize>
+        <BitOffs>102336</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGearInDyn</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_GearInDyn</Type>
         <BitSize>4416</BitSize>
-        <BitOffs>160064</BitOffs>
+        <BitOffs>163072</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGearOut</Name>
         <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_GearOut</Type>
         <BitSize>2112</BitSize>
-        <BitOffs>164480</BitOffs>
+        <BitOffs>167488</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>166592</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>169600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisStatus</Name>
         <Type Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Type>
         <BitSize>768</BitSize>
-        <BitOffs>166720</BitOffs>
+        <BitOffs>169728</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">F_TRIG</Name>
-      <Comment>
-	Falling Edge detection.
-</Comment>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> falling edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
     </DataType>
@@ -13080,6 +27035,348 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_EncoderValue</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion.Tc2_MC2">MC_ReadParameterSet</Name>
+      <BitSize>1984</BitSize>
+      <SubItem>
+        <Name>Parameter</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">ST_AxisParameterSet</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Axis</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Execute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Done</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TriggerExecute</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>state</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRead</Name>
+        <Type Namespace="Tc2_System">ADSREAD</Type>
+        <BitSize>1408</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SizeofPayloadData</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SizeofPayloadData64</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>ActGetSizeOfParameterSet</Name>
+      </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionStageNCParams</Name>
+      <BitSize>2560</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tRefreshDelay</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>mcReadParams</Name>
+        <Type Namespace="lcls_twincat_motion.Tc2_MC2">MC_ReadParameterSet</Type>
+        <BitSize>1984</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>2240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2496</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nLatchErrId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2528</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13089,7 +27386,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionStage</Name>
-      <BitSize>168384</BitSize>
+      <BitSize>174144</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -13105,69 +27402,118 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbDriveVirtual</Name>
         <Type Namespace="lcls_twincat_motion">FB_DriveVirtual</Type>
-        <BitSize>167488</BitSize>
+        <BitSize>170496</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>167616</BitOffs>
+        <BitOffs>170624</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bFwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>167624</BitOffs>
+        <BitOffs>170632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bBwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>167632</BitOffs>
+        <BitOffs>170640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftExec</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>167680</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>170688</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>167808</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>170816</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtUserExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>167936</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>170944</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtTarget</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>168064</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>171072</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetEnables</Name>
         <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
         <BitSize>128</BitSize>
-        <BitOffs>168192</BitOffs>
+        <BitOffs>171200</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPosGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>168320</BitOffs>
+        <BitOffs>171328</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNegGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>168328</BitOffs>
+        <BitOffs>171336</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>fbEncoderValue</Name>
+        <Type Namespace="lcls_twincat_motion">FB_EncoderValue</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>171392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbNCParams</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStageNCParams</Type>
+        <BitSize>2560</BitSize>
+        <BitOffs>171520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewMoveReq</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>174080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bPrepareDisable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>174088</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13177,7 +27523,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionStageSim</Name>
-      <BitSize>168576</BitSize>
+      <BitSize>174400</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -13191,17 +27537,57 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>nEnableMode</Name>
+        <Type Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>fbMotionStage</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>168384</BitSize>
-        <BitOffs>128</BitOffs>
+        <BitSize>174144</BitSize>
+        <BitOffs>192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>168512</BitOffs>
+        <BitOffs>174336</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13238,7 +27624,24 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
+      <Name GUID="{4591E628-DBCE-4E33-AE0B-7EB853AA256E}" Namespace="PLC" TcBaseType="true">EPlcPersistentStatus</Name>
+      <BitSize>8</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000002}">USINT</BaseType>
+      <EnumInfo>
+        <Text>PS_None</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PS_All</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PS_Partial</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name GUID="{941FDF6E-37CE-4C30-AA23-3236AFA461E2}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>ObjId</Name>
@@ -13319,6 +27722,12 @@ External Setpoint Generation:
         <BitOffs>224</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>PersistentStatus</Name>
+        <Type GUID="{4591E628-DBCE-4E33-AE0B-7EB853AA256E}" Namespace="PLC">EPlcPersistentStatus</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>TComSrvPtr</Name>
         <Type GUID="{00000030-0000-0000-E000-000000000064}">ITComObjectServer</Type>
         <BitSize X64="64">32</BitSize>
@@ -13346,6 +27755,7 @@ External Setpoint Generation:
         <Hide GUID="{5DCEB2BC-E196-43AD-80B7-EBACF31A430B}"/>
         <Hide GUID="{1B9FDDE4-B3B7-4F0F-AB14-24EDC2F643E7}"/>
         <Hide GUID="{C1C52E30-BC0B-44CA-BF39-E2FE7F2D145C}"/>
+        <Hide GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}"/>
       </Hides>
     </DataType>
     <DataType>
@@ -13653,6 +28063,66 @@ External Setpoint Generation:
         </Property>
       </Properties>
     </DataType>
+    <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_MotionStage_Extras</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>fVisuStep</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bVisuLowLim</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bVisuHighLim</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+      </SubItem>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{758E956E-09CF-453B-A78C-613FFD98696E}" TcSmClass="TComPlcObjDef">
@@ -13674,18 +28144,35 @@ External Setpoint Generation:
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1114112</ByteSize>
+          <ByteSize>79953920</ByteSize>
+          <Symbol>
+            <Name>lcls_twincat_motion.LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
+            <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
+            <BitSize>48</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
+            <Properties>
+              <Property>
+                <Name>naming</Name>
+                <Value>omit</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>3076920</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4336448</BitOffs>
+            <BitOffs>633673344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -13708,7 +28195,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4344384</BitOffs>
+            <BitOffs>633681280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -13731,7 +28218,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4344392</BitOffs>
+            <BitOffs>633681288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -13754,7 +28241,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4344400</BitOffs>
+            <BitOffs>633681296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -13777,31 +28264,70 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4344416</BitOffs>
+            <BitOffs>633681312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>633681344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>633681408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>633681424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion1.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4349376</BitOffs>
+            <BitOffs>633696128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4516288</BitOffs>
+            <BitOffs>633868800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -13824,7 +28350,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4524224</BitOffs>
+            <BitOffs>633876736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -13847,7 +28373,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4524232</BitOffs>
+            <BitOffs>633876744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -13870,7 +28396,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4524240</BitOffs>
+            <BitOffs>633876752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -13893,31 +28419,70 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4524256</BitOffs>
+            <BitOffs>633876768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>633876800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>633876864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>633876880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4529088</BitOffs>
+            <BitOffs>633891392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4695936</BitOffs>
+            <BitOffs>634064000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -13940,7 +28505,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4703872</BitOffs>
+            <BitOffs>634071936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -13963,7 +28528,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4703880</BitOffs>
+            <BitOffs>634071944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -13986,7 +28551,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4703888</BitOffs>
+            <BitOffs>634071952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -14009,26 +28574,65 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4703904</BitOffs>
+            <BitOffs>634071968</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbMotion3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Name>Main.M3.nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>4708736</BitOffs>
+            <BitOffs>634072000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>634072064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>634072080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotion3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>634086592</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1114112</ByteSize>
+          <ByteSize>79953920</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -14039,7 +28643,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4335424</BitOffs>
+            <BitOffs>633672320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -14062,7 +28666,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4344408</BitOffs>
+            <BitOffs>633681304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion1.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -14074,7 +28678,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4348352</BitOffs>
+            <BitOffs>633695104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -14086,7 +28690,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4515264</BitOffs>
+            <BitOffs>633867776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -14109,7 +28713,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4524248</BitOffs>
+            <BitOffs>633876760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -14121,7 +28725,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4528064</BitOffs>
+            <BitOffs>633890368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -14133,7 +28737,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4694912</BitOffs>
+            <BitOffs>634062976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -14156,7 +28760,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4703896</BitOffs>
+            <BitOffs>634071960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -14168,14 +28772,421 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>4707712</BitOffs>
+            <BitOffs>634085568</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1114112</ByteSize>
+          <ByteSize>79953920</ByteSize>
+          <Symbol>
+            <Name>MOTION_GVL.stUnknownState</Name>
+            <BitSize>2432</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>Unknown</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3072000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.stInvalidState</Name>
+            <BitSize>2432</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_PositionState</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3074432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.MAX_STATES</Name>
+            <Comment> Allocated space for 6 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>6</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3076864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>DefaultGlobals.stSys</Name>
+            <Comment>Included for you</Comment>
+            <BitSize>88</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.LCLS_General">ST_System</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3076880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.bTrickleTripped</Name>
+            <Comment> Global trickle trip flag</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
+		io: i
+		field: DESC Tripped by overall log count
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3076968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.iLogPort</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>54321</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogPort
+		io: io
+		field: DESC The log host UDP port
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3076976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>DefaultGlobals.fTimeStamp</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3076992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.cLogHost</Name>
+            <Comment>
+	Using the IP address directly avoids DNS configuration issues.
+	While we may want to address this in the future, for now the static IP
+	will suffice:
+
+	$ nslookup ctl-logsrv01
+	Name:   ctl-logsrv01.pcdsn
+	Address: 172.21.32.36
+	</Comment>
+            <BitSize>128</BitSize>
+            <BaseType>STRING(15)</BaseType>
+            <Default>
+              <String>172.21.32.36</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogHost
+		io: io
+		field: DESC The log host IP address
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sIpTidbit</Name>
+            <BitSize>56</BitSize>
+            <BaseType>STRING(6)</BaseType>
+            <Default>
+              <String>172.21</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
+            <Comment> Retain data loaded </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTripThreshold</Name>
+            <Comment> Minimum time between log messages</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
+            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_LOGGER</Name>
+            <Comment> Logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
+            <Comment> Default trickle trip, activated by global threshold</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleTripTime</Name>
+            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTripResetPeriod</Name>
+            <Comment> Default time for CB auto-reset</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>600000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sPlcHostname</Name>
+            <BitSize>648</BitSize>
+            <BaseType>STRING(80)</BaseType>
+            <Default>
+              <String>unknown</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3077408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
+            <Comment> Retain data is invalid </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3078056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
+            <Comment> Event logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>110</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3078064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
+            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
+		TODO: Activate the "Replace constants" option in the
+		TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window. 
+	</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3078080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nGlobAccEvents</Name>
+            <Comment> Global log message count</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogMessageCount
+		io: i
+		field: DESC Total log messages on the last cycle
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3078112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.fbRootLogger</Name>
+            <Comment>Instantiated here to be used everywhere</Comment>
+            <BitSize>85696</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3078144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleThreshold</Name>
+            <Comment> If GlobAccEvents goes over this level for longer than the </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3163840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_Standard</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.3.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3163872</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_System</Name>
             <BitSize>288</BitSize>
@@ -14191,7 +29202,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>21</Value>
+                <Value>22</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -14199,7 +29210,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.4.21.0</String>
+                <String>3.4.22.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -14210,37 +29221,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_LOGGER</Name>
-            <Comment> Logger </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
-            <Comment> Event logger </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>110</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096304</BitOffs>
+            <BitOffs>3164160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
@@ -14255,7 +29236,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096320</BitOffs>
+            <BitOffs>3164448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_IO</Name>
@@ -14270,7 +29251,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096336</BitOffs>
+            <BitOffs>3164464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NC</Name>
@@ -14284,7 +29265,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096352</BitOffs>
+            <BitOffs>3164480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSAF</Name>
@@ -14298,7 +29279,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096368</BitOffs>
+            <BitOffs>3164496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSVB</Name>
@@ -14312,7 +29293,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096384</BitOffs>
+            <BitOffs>3164512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_ISG</Name>
@@ -14326,7 +29307,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096400</BitOffs>
+            <BitOffs>3164528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CNC</Name>
@@ -14340,7 +29321,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096416</BitOffs>
+            <BitOffs>3164544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_LINE</Name>
@@ -14354,7 +29335,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096432</BitOffs>
+            <BitOffs>3164560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC</Name>
@@ -14368,7 +29349,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096448</BitOffs>
+            <BitOffs>3164576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS1</Name>
@@ -14383,7 +29364,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096464</BitOffs>
+            <BitOffs>3164592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS2</Name>
@@ -14398,7 +29379,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096480</BitOffs>
+            <BitOffs>3164608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS3</Name>
@@ -14413,7 +29394,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096496</BitOffs>
+            <BitOffs>3164624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS4</Name>
@@ -14428,7 +29409,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096512</BitOffs>
+            <BitOffs>3164640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAM</Name>
@@ -14442,7 +29423,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096528</BitOffs>
+            <BitOffs>3164656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAMTOOL</Name>
@@ -14457,7 +29438,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096544</BitOffs>
+            <BitOffs>3164672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
@@ -14472,7 +29453,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096560</BitOffs>
+            <BitOffs>3164688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -14487,7 +29468,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096576</BitOffs>
+            <BitOffs>3164704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INVALID</Name>
@@ -14502,7 +29483,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096592</BitOffs>
+            <BitOffs>3164720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_IDLE</Name>
@@ -14516,7 +29497,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096608</BitOffs>
+            <BitOffs>3164736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESET</Name>
@@ -14530,7 +29511,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096624</BitOffs>
+            <BitOffs>3164752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INIT</Name>
@@ -14544,7 +29525,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096640</BitOffs>
+            <BitOffs>3164768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_START</Name>
@@ -14558,7 +29539,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096656</BitOffs>
+            <BitOffs>3164784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RUN</Name>
@@ -14572,7 +29553,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096672</BitOffs>
+            <BitOffs>3164800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOP</Name>
@@ -14586,7 +29567,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096688</BitOffs>
+            <BitOffs>3164816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SAVECFG</Name>
@@ -14600,7 +29581,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096704</BitOffs>
+            <BitOffs>3164832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_LOADCFG</Name>
@@ -14614,7 +29595,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096720</BitOffs>
+            <BitOffs>3164848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERFAILURE</Name>
@@ -14628,7 +29609,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096736</BitOffs>
+            <BitOffs>3164864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERGOOD</Name>
@@ -14642,7 +29623,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096752</BitOffs>
+            <BitOffs>3164880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_ERROR</Name>
@@ -14656,7 +29637,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096768</BitOffs>
+            <BitOffs>3164896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SHUTDOWN</Name>
@@ -14670,7 +29651,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096784</BitOffs>
+            <BitOffs>3164912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SUSPEND</Name>
@@ -14684,7 +29665,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096800</BitOffs>
+            <BitOffs>3164928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESUME</Name>
@@ -14698,7 +29679,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096816</BitOffs>
+            <BitOffs>3164944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_CONFIG</Name>
@@ -14713,7 +29694,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096832</BitOffs>
+            <BitOffs>3164960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RECONFIG</Name>
@@ -14728,7 +29709,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096848</BitOffs>
+            <BitOffs>3164976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOPPING</Name>
@@ -14742,7 +29723,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096864</BitOffs>
+            <BitOffs>3164992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INCOMPATIBLE</Name>
@@ -14756,7 +29737,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096880</BitOffs>
+            <BitOffs>3165008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_EXCEPTION</Name>
@@ -14770,7 +29751,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096896</BitOffs>
+            <BitOffs>3165024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_MAXSTATES</Name>
@@ -14785,7 +29766,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096912</BitOffs>
+            <BitOffs>3165040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
@@ -14800,7 +29781,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096928</BitOffs>
+            <BitOffs>3165056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
@@ -14815,7 +29796,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096960</BitOffs>
+            <BitOffs>3165088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
@@ -14830,7 +29811,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096992</BitOffs>
+            <BitOffs>3165120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
@@ -14844,7 +29825,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097024</BitOffs>
+            <BitOffs>3165152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
@@ -14858,7 +29839,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097056</BitOffs>
+            <BitOffs>3165184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
@@ -14872,7 +29853,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097088</BitOffs>
+            <BitOffs>3165216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
@@ -14886,7 +29867,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097120</BitOffs>
+            <BitOffs>3165248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
@@ -14900,7 +29881,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097152</BitOffs>
+            <BitOffs>3165280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
@@ -14914,7 +29895,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097184</BitOffs>
+            <BitOffs>3165312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
@@ -14928,7 +29909,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097216</BitOffs>
+            <BitOffs>3165344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
@@ -14942,7 +29923,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097248</BitOffs>
+            <BitOffs>3165376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
@@ -14956,7 +29937,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097280</BitOffs>
+            <BitOffs>3165408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
@@ -14970,7 +29951,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097312</BitOffs>
+            <BitOffs>3165440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
@@ -14985,7 +29966,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097344</BitOffs>
+            <BitOffs>3165472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
@@ -15000,7 +29981,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097376</BitOffs>
+            <BitOffs>3165504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
@@ -15015,7 +29996,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097408</BitOffs>
+            <BitOffs>3165536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
@@ -15030,7 +30011,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097440</BitOffs>
+            <BitOffs>3165568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
@@ -15045,7 +30026,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097472</BitOffs>
+            <BitOffs>3165600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
@@ -15060,7 +30041,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097504</BitOffs>
+            <BitOffs>3165632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
@@ -15075,7 +30056,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097536</BitOffs>
+            <BitOffs>3165664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
@@ -15090,7 +30071,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097568</BitOffs>
+            <BitOffs>3165696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
@@ -15105,7 +30086,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097600</BitOffs>
+            <BitOffs>3165728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
@@ -15120,7 +30101,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097632</BitOffs>
+            <BitOffs>3165760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
@@ -15135,7 +30116,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097664</BitOffs>
+            <BitOffs>3165792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
@@ -15150,7 +30131,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097696</BitOffs>
+            <BitOffs>3165824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
@@ -15165,7 +30146,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097728</BitOffs>
+            <BitOffs>3165856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
@@ -15180,7 +30161,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097760</BitOffs>
+            <BitOffs>3165888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
@@ -15195,7 +30176,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097792</BitOffs>
+            <BitOffs>3165920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
@@ -15210,7 +30191,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097824</BitOffs>
+            <BitOffs>3165952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
@@ -15225,7 +30206,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097856</BitOffs>
+            <BitOffs>3165984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
@@ -15240,7 +30221,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097888</BitOffs>
+            <BitOffs>3166016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
@@ -15254,7 +30235,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097920</BitOffs>
+            <BitOffs>3166048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
@@ -15268,7 +30249,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097952</BitOffs>
+            <BitOffs>3166080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
@@ -15282,7 +30263,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097984</BitOffs>
+            <BitOffs>3166112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
@@ -15296,7 +30277,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098016</BitOffs>
+            <BitOffs>3166144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
@@ -15310,7 +30291,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098048</BitOffs>
+            <BitOffs>3166176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
@@ -15324,7 +30305,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098080</BitOffs>
+            <BitOffs>3166208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
@@ -15338,7 +30319,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098112</BitOffs>
+            <BitOffs>3166240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
@@ -15352,7 +30333,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098144</BitOffs>
+            <BitOffs>3166272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
@@ -15366,7 +30347,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098176</BitOffs>
+            <BitOffs>3166304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
@@ -15380,7 +30361,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098208</BitOffs>
+            <BitOffs>3166336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
@@ -15394,7 +30375,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098240</BitOffs>
+            <BitOffs>3166368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
@@ -15408,7 +30389,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098272</BitOffs>
+            <BitOffs>3166400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
@@ -15422,7 +30403,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098304</BitOffs>
+            <BitOffs>3166432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
@@ -15436,7 +30417,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098336</BitOffs>
+            <BitOffs>3166464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
@@ -15450,7 +30431,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098368</BitOffs>
+            <BitOffs>3166496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
@@ -15464,7 +30445,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098400</BitOffs>
+            <BitOffs>3166528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
@@ -15478,7 +30459,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098432</BitOffs>
+            <BitOffs>3166560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
@@ -15492,7 +30473,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098464</BitOffs>
+            <BitOffs>3166592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
@@ -15506,7 +30487,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098496</BitOffs>
+            <BitOffs>3166624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
@@ -15520,7 +30501,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098528</BitOffs>
+            <BitOffs>3166656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
@@ -15535,7 +30516,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098560</BitOffs>
+            <BitOffs>3166688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
@@ -15549,7 +30530,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098592</BitOffs>
+            <BitOffs>3166720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
@@ -15563,7 +30544,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098624</BitOffs>
+            <BitOffs>3166752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
@@ -15577,7 +30558,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098656</BitOffs>
+            <BitOffs>3166784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
@@ -15591,7 +30572,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098688</BitOffs>
+            <BitOffs>3166816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
@@ -15606,7 +30587,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098720</BitOffs>
+            <BitOffs>3166848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
@@ -15621,7 +30602,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098752</BitOffs>
+            <BitOffs>3166880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
@@ -15636,7 +30617,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098784</BitOffs>
+            <BitOffs>3166912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
@@ -15651,7 +30632,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098816</BitOffs>
+            <BitOffs>3166944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
@@ -15666,7 +30647,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098848</BitOffs>
+            <BitOffs>3166976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
@@ -15680,7 +30661,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098880</BitOffs>
+            <BitOffs>3167008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
@@ -15694,37 +30675,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
-            <Comment> Retain data loaded </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4098944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
-            <Comment> Retain data is invalid </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4098952</BitOffs>
+            <BitOffs>3167040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
@@ -15738,7 +30689,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098960</BitOffs>
+            <BitOffs>3167072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
@@ -15753,7 +30704,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098968</BitOffs>
+            <BitOffs>3167080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_INVALID</Name>
@@ -15768,7 +30719,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098976</BitOffs>
+            <BitOffs>3167088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_BSOD</Name>
@@ -15783,7 +30734,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098984</BitOffs>
+            <BitOffs>3167096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_RTVIOLATION</Name>
@@ -15798,7 +30749,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4098992</BitOffs>
+            <BitOffs>3167104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.nWatchdogTime</Name>
@@ -15810,97 +30761,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEREAD</Name>
-            <Comment>"r": Opens for reading. If the file does not exist or cannot be found, the call fails.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEWRITE</Name>
-            <Comment>"w": Opens an empty file for writing. If the given file exists, its contents are destroyed.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
-            <Comment>"a": Opens for writing at the end of the file (appending) without removing the EOF marker before writing new data to the file; creates the file first if it doesnot exist.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEPLUS</Name>
-            <Comment>"+": Opens for reading and writing</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEBINARY</Name>
-            <Comment>"b": Open in binary (untranslated) mode.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODETEXT</Name>
-            <Comment>"t": Open in text (translated) mode.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099168</BitOffs>
+            <BitOffs>3167112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
@@ -15915,7 +30776,97 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099424</BitOffs>
+            <BitOffs>3167120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEREAD</Name>
+            <Comment>"r": Opens for reading. If the file does not exist or cannot be found, the call fails.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3167136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEWRITE</Name>
+            <Comment>"w": Opens an empty file for writing. If the given file exists, its contents are destroyed.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3167168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
+            <Comment>"a": Opens for writing at the end of the file (appending) without removing the EOF marker before writing new data to the file; creates the file first if it doesnot exist.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3167200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEPLUS</Name>
+            <Comment>"+": Opens for reading and writing</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3167232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEBINARY</Name>
+            <Comment>"b": Open in binary (untranslated) mode.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3167264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODETEXT</Name>
+            <Comment>"t": Open in text (translated) mode.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3167296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_FMTSELF</Name>
@@ -15930,7 +30881,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099440</BitOffs>
+            <BitOffs>3167552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_LOG</Name>
@@ -15945,7 +30896,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099456</BitOffs>
+            <BitOffs>3167568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_MSGBOX</Name>
@@ -15960,7 +30911,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099472</BitOffs>
+            <BitOffs>3167584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_SRCID</Name>
@@ -15975,7 +30926,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099488</BitOffs>
+            <BitOffs>3167600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_AUTOFMTALL</Name>
@@ -15989,7 +30940,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099504</BitOffs>
+            <BitOffs>3167616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_INVALID</Name>
@@ -16004,7 +30955,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099520</BitOffs>
+            <BitOffs>3167632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_SIGNALED</Name>
@@ -16019,7 +30970,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099536</BitOffs>
+            <BitOffs>3167648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESET</Name>
@@ -16034,7 +30985,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099552</BitOffs>
+            <BitOffs>3167664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_CONFIRMED</Name>
@@ -16049,7 +31000,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099568</BitOffs>
+            <BitOffs>3167680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESETCON</Name>
@@ -16064,7 +31015,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099584</BitOffs>
+            <BitOffs>3167696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_SRCNAMESIZE</Name>
@@ -16078,7 +31029,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099600</BitOffs>
+            <BitOffs>3167712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_FMTPRGSIZE</Name>
@@ -16092,21 +31043,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.eWatchdogConfig</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4099632</BitOffs>
+            <BitOffs>3167728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -16120,7 +31057,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099648</BitOffs>
+            <BitOffs>3167744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
@@ -16135,7 +31072,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099712</BitOffs>
+            <BitOffs>3167808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_STRING_LENGTH</Name>
@@ -16150,7 +31087,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4099744</BitOffs>
+            <BitOffs>3167840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.eWatchdogConfig</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3168384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_Module</Name>
@@ -16167,7 +31118,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>20</Value>
+                <Value>21</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -16175,7 +31126,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.3.20.0</String>
+                <String>3.3.21.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -16186,7 +31137,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4100288</BitOffs>
+            <BitOffs>3168416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
+            <Comment> TRUE = Enable DCF77 telegram plausibility check (two telegrams are checked), FALSE = Disable check </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3169016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
@@ -16203,15 +31169,19 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>35</Value>
+                <Value>38</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
                 <Value>0</Value>
               </SubItem>
               <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.3.35.0</String>
+                <String>3.3.38.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -16222,30 +31192,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4100928</BitOffs>
+            <BitOffs>3169088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
             <Comment> Max. number of measures used in the profiler function block: 2..100 </Comment>
             <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <BaseType>INT (2..100)</BaseType>
             <Default>
               <Value>10</Value>
             </Default>
             <Properties>
               <Property>
-                <Name>LowerBorder</Name>
-                <Value>2</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4101216</BitOffs>
+            <BitOffs>3169440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
@@ -16260,7 +31222,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4101232</BitOffs>
+            <BitOffs>3169456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
@@ -16275,22 +31237,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4101248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
-            <Comment> TRUE = Enable DCF77 telegram plausibility check (two telegrams are checked), FALSE = Disable check </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4101264</BitOffs>
+            <BitOffs>3169472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_SEP</Name>
@@ -16305,202 +31252,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4101272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
-            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>140</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4101280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
-            <Comment> Max. System Service local adapter name length (256 + 4 inkl. \0) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>259</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
-            <Comment> Max. System Service local adapter descirpion length (128 + 4 inkl. \0) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>131</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
-            <Comment> Max. System Service local adapter physical address length (bytes[0..7]) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>7</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
-            <Comment> IPHELPERAPI index group </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>701</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
-            <Comment> IPHOSTNAME index group </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>702</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
-            <Comment> IPHELPERAPI index offset </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
-            <Comment> IPHELPERAPI index offset </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4162976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
-            <Comment> Max. number of local network adapters </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
-            <Comment> System Service route function: Add route </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>801</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
-            <Comment> System Service route function: Delete route  </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>802</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
-            <Comment> System Service route function: Enumerater route </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>803</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
-            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>99</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163136</BitOffs>
+            <BitOffs>3169488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
@@ -16515,7 +31267,202 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4163152</BitOffs>
+            <BitOffs>3169496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
+            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>140</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3169504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
+            <Comment> Max. System Service local adapter name length (256 + 4 inkl. \0) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>259</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
+            <Comment> Max. System Service local adapter descirpion length (128 + 4 inkl. \0) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>131</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
+            <Comment> Max. System Service local adapter physical address length (bytes[0..7]) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>7</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
+            <Comment> IPHELPERAPI index group </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>701</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
+            <Comment> IPHOSTNAME index group </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>702</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
+            <Comment> IPHELPERAPI index offset </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
+            <Comment> IPHELPERAPI index offset </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
+            <Comment> Max. number of local network adapters </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
+            <Comment> System Service route function: Add route </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>801</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
+            <Comment> System Service route function: Delete route  </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>802</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
+            <Comment> System Service route function: Enumerater route </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>803</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
+            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>99</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_ADDR_LEN</Name>
@@ -16530,52 +31477,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4163160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
-            <Comment> TwinCAT route flag: Temporary </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
-            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
-            <Comment> TwinCAT route flag: No override </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4163232</BitOffs>
+            <BitOffs>3231376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MIN_ROUTE_TRANSPORT</Name>
@@ -16590,7 +31492,52 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4163264</BitOffs>
+            <BitOffs>3231384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
+            <Comment> TwinCAT route flag: Temporary </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
+            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
+            <Comment> TwinCAT route flag: No override </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_TRANSPORT</Name>
@@ -16605,7 +31552,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4163272</BitOffs>
+            <BitOffs>3231488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
+            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>34</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3231496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
@@ -16620,7 +31582,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4163280</BitOffs>
+            <BitOffs>3231504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ROUTE_ENTRY</Name>
@@ -16654,7 +31616,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4163296</BitOffs>
+            <BitOffs>3231520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FFILEFIND</Name>
@@ -16669,7 +31631,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164480</BitOffs>
+            <BitOffs>3232704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.HKEY_MAX_BINARY_DATA_SIZE</Name>
@@ -16684,7 +31646,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164512</BitOffs>
+            <BitOffs>3232736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IGR_GENERAL</Name>
@@ -16699,7 +31661,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164544</BitOffs>
+            <BitOffs>3232768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IOF_MODE</Name>
@@ -16714,7 +31676,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164576</BitOffs>
+            <BitOffs>3232800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_MAX_ARGS</Name>
@@ -16729,7 +31691,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164608</BitOffs>
+            <BitOffs>3232832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_NAN</Name>
@@ -16744,7 +31706,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164624</BitOffs>
+            <BitOffs>3232848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_INF</Name>
@@ -16759,7 +31721,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164640</BitOffs>
+            <BitOffs>3232864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_DIGITS</Name>
@@ -16774,7 +31736,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164656</BitOffs>
+            <BitOffs>3232880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_PRECISION</Name>
@@ -16789,7 +31751,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164672</BitOffs>
+            <BitOffs>3232896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MIN_PRECISION</Name>
@@ -16804,7 +31766,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164688</BitOffs>
+            <BitOffs>3232912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_NOERROR</Name>
@@ -16819,7 +31781,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164704</BitOffs>
+            <BitOffs>3232928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PERCENTSIGNPOSITION</Name>
@@ -16834,7 +31796,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164736</BitOffs>
+            <BitOffs>3232960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ASTERISKPOSITION</Name>
@@ -16849,7 +31811,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164768</BitOffs>
+            <BitOffs>3232992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHVALUE</Name>
@@ -16864,7 +31826,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164800</BitOffs>
+            <BitOffs>3233024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONVALUE</Name>
@@ -16879,7 +31841,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164832</BitOffs>
+            <BitOffs>3233056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_FLAGPOSITION</Name>
@@ -16894,7 +31856,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164864</BitOffs>
+            <BitOffs>3233088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHPRECISIONVALPOS</Name>
@@ -16909,7 +31871,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164896</BitOffs>
+            <BitOffs>3233120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONDOTPOSITION</Name>
@@ -16924,7 +31886,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164928</BitOffs>
+            <BitOffs>3233152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_TYPEFIELDVALUE</Name>
@@ -16939,7 +31901,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164960</BitOffs>
+            <BitOffs>3233184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ARGTYPEINVALID</Name>
@@ -16954,7 +31916,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4164992</BitOffs>
+            <BitOffs>3233216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_UNACCEPTEDPARAMETER</Name>
@@ -16969,7 +31931,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165024</BitOffs>
+            <BitOffs>3233248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INSUFFICIENTARGS</Name>
@@ -16984,7 +31946,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165056</BitOffs>
+            <BitOffs>3233280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_DESTBUFFOVERFLOW</Name>
@@ -16999,7 +31961,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165088</BitOffs>
+            <BitOffs>3233312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INVALIDPOINTERINPUT</Name>
@@ -17014,7 +31976,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165120</BitOffs>
+            <BitOffs>3233344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
@@ -17029,7 +31991,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165152</BitOffs>
+            <BitOffs>3233376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ARG_VALUE</Name>
@@ -17055,7 +32017,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165184</BitOffs>
+            <BitOffs>3233408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_HEXASC_CODES</Name>
@@ -17204,7 +32166,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165312</BitOffs>
+            <BitOffs>3233536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_DECASC_CODES</Name>
@@ -17262,7 +32224,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4165568</BitOffs>
+            <BitOffs>3233792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_MONTHDAYS</Name>
@@ -17379,7 +32341,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4171056</BitOffs>
+            <BitOffs>3239280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_YEARSDAY</Name>
@@ -17512,7 +32474,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4171440</BitOffs>
+            <BitOffs>3239664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC</Name>
@@ -17534,7 +32496,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4171904</BitOffs>
+            <BitOffs>3240128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC</Name>
@@ -17556,7 +32518,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4171968</BitOffs>
+            <BitOffs>3240192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY</Name>
@@ -17578,7 +32540,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172032</BitOffs>
+            <BitOffs>3240256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN</Name>
@@ -17600,7 +32562,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172096</BitOffs>
+            <BitOffs>3240320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX</Name>
@@ -17622,7 +32584,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172160</BitOffs>
+            <BitOffs>3240384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC64</Name>
@@ -17637,7 +32599,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172224</BitOffs>
+            <BitOffs>3240448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC64</Name>
@@ -17652,7 +32614,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172288</BitOffs>
+            <BitOffs>3240512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY64</Name>
@@ -17667,7 +32629,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172352</BitOffs>
+            <BitOffs>3240576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN64</Name>
@@ -17682,7 +32644,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172416</BitOffs>
+            <BitOffs>3240640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX64</Name>
@@ -17697,7 +32659,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172480</BitOffs>
+            <BitOffs>3240704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.WEST_EUROPE_TZI</Name>
@@ -17770,7 +32732,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4172544</BitOffs>
+            <BitOffs>3240768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
@@ -17785,7 +32747,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4177536</BitOffs>
+            <BitOffs>3245760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERWEEK</Name>
@@ -17800,7 +32762,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4177568</BitOffs>
+            <BitOffs>3245792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_NONE</Name>
@@ -17815,7 +32777,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183776</BitOffs>
+            <BitOffs>3252000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_LOG</Name>
@@ -17830,7 +32792,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183808</BitOffs>
+            <BitOffs>3252032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_FILE</Name>
@@ -17845,7 +32807,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183840</BitOffs>
+            <BitOffs>3252064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_VISU</Name>
@@ -17860,22 +32822,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
-            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>34</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4303568</BitOffs>
+            <BitOffs>3252096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_CR</Name>
@@ -17890,7 +32837,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303576</BitOffs>
+            <BitOffs>3371856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_LF</Name>
@@ -17905,7 +32852,48 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303584</BitOffs>
+            <BitOffs>3371864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
+            <Comment> TcUnit logs complete test results. These include:
+         - Number of test suites
+         - Number of tests
+         - Number of successful tests
+         - Number of failed tests
+         - Any eventual failed assertion (with the expected &amp; actual value plus an user defined message)
+       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
+
+       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
+       These statistics are more detailed results of the tests. This information is used when results are
+       being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
+       This extra information however takes time to print, so by setting the following parameter to FALSE
+       it will speed up TcUnit finishing. </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3371896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Constants.EMPTY_SEVERITY</Name>
+            <BitSize>16</BitSize>
+            <BaseType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3373584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRUCT</Name>
@@ -17962,7 +32950,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4305312</BitOffs>
+            <BitOffs>3373600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRING</Name>
@@ -17976,7 +32964,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4305440</BitOffs>
+            <BitOffs>3373728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_REGSTRING</Name>
@@ -17990,7 +32978,1370 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4305736</BitOffs>
+            <BitOffs>3374024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_ModbusSrv</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.2.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3374336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_SerialCom</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>7</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.7.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3374624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Constants.EMPTY_EVENT_CLASS</Name>
+            <BitSize>128</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.Data1</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data2</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data3</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[0]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[1]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[2]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[3]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[4]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[5]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[6]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[7]</Name>
+                <Value>0</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3374912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Constants.EMPTY_EVENT_ID</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Constants.SUCCESS_EVENT</Name>
+            <BitSize>192</BitSize>
+            <BaseType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.uuidEventClass.Data1</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data2</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data3</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[0]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[1]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[2]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[3]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[4]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[5]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[6]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.uuidEventClass.Data4[7]</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEventID</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.eSeverity</Name>
+                <Value>0</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL.nLangId_OnlineMonitoring</Name>
+            <Comment> language id for online monitoring; English(US)=1033 ; German(Germay)=1031</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DINT</BaseType>
+            <Default>
+              <Value>1033</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>ParameterList.cSourceNameSize</Name>
+            <Comment> size [bytes] for source names</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT (81..Tc2_Utilities.ParameterList.cMaxCharacters)</BaseType>
+            <Default>
+              <Value>256</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc3_EventLogger</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>23</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.1.23.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_INTERNAL.UNINITIALIZED_CLASS_GUID</Name>
+            <Comment> {E7A4B1E0-F4CF-4733-95D5-73DF084B60F8}</Comment>
+            <BitSize>128</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.Data1</Name>
+                <Value>3886330336</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data2</Name>
+                <Value>62671</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data3</Name>
+                <Value>18227</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[0]</Name>
+                <Value>149</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[1]</Name>
+                <Value>213</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[2]</Name>
+                <Value>115</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[3]</Name>
+                <Value>223</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[4]</Name>
+                <Value>8</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[5]</Name>
+                <Value>75</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[6]</Name>
+                <Value>96</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[7]</Name>
+                <Value>248</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>8192</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc3_JsonXml</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>12</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.12.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3375776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
+            <Comment> Enable (TRUE) or disable (FALSE) publishing of the xUnit Xml report </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
+            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
+            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>65535</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
+            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Default>
+              <String>C:\tcunit_xunit_testresults.xml</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3376160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
+            <Comment> This is the maximum number of ADS-messages that can be stored for reporting at the same time.
+       Having a size of 2000 means that it's possible to report up to ~400 test cases in one single
+       PLC cycle. Each entry consumes around 500 bytes, so with an example of a ring buffer size of
+       2000 it means that TcUnit will consume around 1 MB of router memory. </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>2000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3378208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
+            <Comment> Whether or not the current test being called has finished running </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3378224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
+            <Comment> This is a flag that indicates that the current test should be ignored, and
+       thus that all assertions under it should be ignored as well. A test can be ignored either
+       because the user has requested so, or because the test is a duplicate name </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3378232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TcUnitRunner</Name>
+            <BitSize>621828160</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TcUnitRunner</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3378240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
+            <Comment> Pointer to current test suite being called </Comment>
+            <BitSize>64</BitSize>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625206400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
+            <Comment> Current name of test being called </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625206464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
+            <Comment> The assert function block instance should be 1:1 mapped to
+       the test suite instance path. </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625208512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_STOPPERS</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625208528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TestSuiteAddresses</Name>
+            <BitSize>64000</BitSize>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>1000</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625208576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.AdsMessageQueue</Name>
+            <Comment> Buffered ADS message queue for output to the error list </Comment>
+            <BitSize>8321152</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.LCLS_General.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625272576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_TcUnit</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>1.1.0.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633593728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stRequestedBeamParameters</Name>
+            <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)RequestedBP
+		io: i
+        archive: 1Hz monitor
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633594016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stCurrentBeamParameters</Name>
+            <Comment>Currently active BP set, broadcast by the line arbiter PLC</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)CurrentBP
+		io: i
+        archive: 1Hz monitor
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633595232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_areVBoundaries</Name>
+            <BitSize>512</BitSize>
+            <BaseType>REAL</BaseType>
+            <ArrayInfo>
+              <LBound>0</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)eVRangeCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Active eV Range constants
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633596448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.PERange</Name>
+            <Comment>Included to place the ev ranges properly</Comment>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">PE_Ranges</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633596992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
+            <Comment>An assertion ID that should always return "not found" in the assertion pool</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4294967295</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633597056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633597088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633597120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633597184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fPP_mJ</Name>
+                <Value>10000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.neVRange</Name>
+                <Value>65535</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nRate</Name>
+                <Value>1000000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[1].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[1].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[2].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[2].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[3].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[3].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[4].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[4].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633597248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fPP_mJ</Name>
+                <Value>10000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.neVRange</Name>
+                <Value>65535</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nRate</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[1].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[1].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[2].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[2].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[3].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[3].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[4].Width</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.astApertures[4].Height</Name>
+                <Value>1000</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633598464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstSafeBeam</Name>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fPP_mJ</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.neVRange</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nRate</Name>
+                <Value>0</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)SafeBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Safe beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633599680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>20</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633600896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633600912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_APERTURES</Name>
+            <Comment> Maximum # of power slits in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633600928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
+            <BitSize>512</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Attenuator</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633600944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>15</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633601456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.reVHyst</Name>
+            <Comment>///////////////////////
+///////////////////////
+////////////////////////////////////		</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)eVRangeHyst
+		io: i
+        archive: 1Hz monitor
+        field: DESC eV Range hystersis
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633601472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_areVBoundariesL</Name>
+            <BitSize>512</BitSize>
+            <BaseType>REAL</BaseType>
+            <ArrayInfo>
+              <LBound>0</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Default>
+              <SubItem>
+                <Name>[0]</Name>
+                <Value>1700</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[1]</Name>
+                <Value>2500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[2]</Name>
+                <Value>5000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[3]</Name>
+                <Value>7000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[4]</Name>
+                <Value>7700</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[5]</Name>
+                <Value>8900</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[6]</Name>
+                <Value>10000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[7]</Name>
+                <Value>11100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[8]</Name>
+                <Value>12000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[9]</Name>
+                <Value>14000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[10]</Name>
+                <Value>16000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[11]</Name>
+                <Value>16900</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[12]</Name>
+                <Value>18000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[13]</Name>
+                <Value>20000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[14]</Name>
+                <Value>22000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[15]</Name>
+                <Value>24000</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)L:eVRangeCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC eV Range constants
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633601504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_areVBoundariesK</Name>
+            <BitSize>512</BitSize>
+            <BaseType>REAL</BaseType>
+            <ArrayInfo>
+              <LBound>0</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Default>
+              <SubItem>
+                <Name>[0]</Name>
+                <Value>250</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[1]</Name>
+                <Value>270</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[2]</Name>
+                <Value>400</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[3]</Name>
+                <Value>540</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[4]</Name>
+                <Value>850</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[5]</Name>
+                <Value>1150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[6]</Name>
+                <Value>1250</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[7]</Name>
+                <Value>1450</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[8]</Name>
+                <Value>1550</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[9]</Name>
+                <Value>1650</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[10]</Name>
+                <Value>1750</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[11]</Name>
+                <Value>1820</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[12]</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[13]</Name>
+                <Value>3200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[14]</Name>
+                <Value>5000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[15]</Name>
+                <Value>7100</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)K:eVRangeCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC eV Range constants
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
+            <Comment>Maximum number of assertions permitted in the arbiter</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>20</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bFPUSupport</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_TOOLS.fbJson</Name>
+            <BitSize>384</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633602624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -18007,19 +34358,15 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>29</Value>
+                <Value>39</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
                 <Value>0</Value>
               </SubItem>
               <SubItem>
-                <Name>.nFlags</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.3.29.0</String>
+                <String>3.3.39.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -18030,26 +34377,25 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4306048</BitOffs>
+            <BitOffs>633603008</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
             <Default>
-              <Value>1</Value>
+              <Value>8</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4306336</BitOffs>
+            <BitOffs>633603296</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Name>Constants.bMulticoreSupport</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
@@ -18060,22 +34406,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4306344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4306352</BitOffs>
+            <BitOffs>633603312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -18086,7 +34417,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4306368</BitOffs>
+            <BitOffs>633603328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -18100,7 +34431,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4313472</BitOffs>
+            <BitOffs>633610432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -18114,12 +34445,63 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4313536</BitOffs>
+            <BitOffs>633610496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_Math</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.1.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633610560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.RuntimeVersionNumeric</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>50662656</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633610848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
             <Comment> Simulated motor that is always allowed to move</Comment>
-            <BitSize>11264</BitSize>
+            <BitSize>21056</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -18130,18 +34512,18 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>4335360</BitOffs>
+            <BitOffs>633672256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion1</Name>
-            <BitSize>168576</BitSize>
+            <BitSize>174400</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStageSim</BaseType>
-            <BitOffs>4346624</BitOffs>
+            <BitOffs>633693312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
             <Comment> Simulated motor that is never allowed to move</Comment>
-            <BitSize>11264</BitSize>
+            <BitSize>21056</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -18152,18 +34534,18 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>4515200</BitOffs>
+            <BitOffs>633867712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion2</Name>
-            <BitSize>168384</BitSize>
+            <BitSize>174144</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>4526464</BitOffs>
+            <BitOffs>633888768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
             <Comment> Simulated motor with limits at 0 and 100</Comment>
-            <BitSize>11264</BitSize>
+            <BitSize>21056</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -18174,17 +34556,17 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>4694848</BitOffs>
+            <BitOffs>634062912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotion3</Name>
-            <BitSize>168384</BitSize>
+            <BitSize>174144</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>4706112</BitOffs>
+            <BitOffs>634083968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>64</BitSize>
             <BaseType>VERSION</BaseType>
             <Default>
@@ -18198,7 +34580,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.uiServicePack</Name>
-                <Value>6</Value>
+                <Value>13</Value>
               </SubItem>
               <SubItem>
                 <Name>.uiPatch</Name>
@@ -18210,11 +34592,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4879424</BitOffs>
+            <BitOffs>634259136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>64</BitSize>
             <BaseType>VERSION</BaseType>
             <Default>
@@ -18228,11 +34610,11 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.uiServicePack</Name>
-                <Value>10</Value>
+                <Value>13</Value>
               </SubItem>
               <SubItem>
                 <Name>.uiPatch</Name>
-                <Value>100</Value>
+                <Value>40</Value>
               </SubItem>
             </Default>
             <Properties>
@@ -18240,64 +34622,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4879488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4879552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bFPUSupport</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4879568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.RuntimeVersionNumeric</Name>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>50660864</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4879584</BitOffs>
+            <BitOffs>634259200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>32</BitSize>
             <BaseType>DWORD</BaseType>
             <Default>
-              <Value>50661988</Value>
+              <Value>50662696</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4879616</BitOffs>
+            <BitOffs>634259264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -18311,12 +34651,12 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>5247072</BitOffs>
+            <BitOffs>634259296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}">PlcAppSystemInfo</BaseType>
+            <BaseType GUID="{941FDF6E-37CE-4C30-AA23-3236AFA461E2}">PlcAppSystemInfo</BaseType>
             <Properties>
               <Property>
                 <Name>no_init</Name>
@@ -18325,7 +34665,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>5247104</BitOffs>
+            <BitOffs>634259328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -18343,7 +34683,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>5249152</BitOffs>
+            <BitOffs>634261376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -18357,7 +34697,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>5250176</BitOffs>
+            <BitOffs>634262400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -18378,12 +34718,104 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>5250240</BitOffs>
+            <BitOffs>634262464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>init_on_onlchange</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634310976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.stM1Extra</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage_Extras</BaseType>
+            <BitOffs>634693504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.stM2Extra</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage_Extras</BaseType>
+            <BitOffs>634693632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.stM3Extra</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage_Extras</BaseType>
+            <BitOffs>637647808</BitOffs>
+          </Symbol>
+        </DataArea>
+        <DataArea>
+          <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
+          <Name>PlcTask Retains</Name>
+          <ContextId>0</ContextId>
+          <ByteSize>79953920</ByteSize>
+          <Symbol>
+            <Name>PMPS_GVL.SuccessfulPreemption</Name>
+            <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)SuccessfulPreemptions
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625208544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AccumulatedFF</Name>
+            <Comment> Any time a FF occurs</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)AccumulatedFastFaults
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633596960</BitOffs>
           </Symbol>
         </DataArea>
       </DataAreas>
       <Deployment/>
-      <EventClasses/>
+      <EventClasses>
+        <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
+      </EventClasses>
       <Properties>
         <Property>
           <Name>ApplicationName</Name>
@@ -18391,15 +34823,15 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2020-04-24T15:17:43</Value>
+          <Value>2020-10-26T10:56:25</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>360448</Value>
+          <Value>479232</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>155648</Value>
+          <Value>78925824</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
* Relies on the existence of VISU_MotionStage in lcls-twincat-motion
* Changes settings to 4024, probably unacceptably

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/5139267/97210199-79b0a200-177a-11eb-8a47-833fe03110f5.png">
